### PR TITLE
Resident Evil 1 PSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,15 +47,3 @@ luac.out
 
 # Editor settings
 .vscode/
-/.vs/bizhawk-shuffler-2-phiggle-fork/FileContentIndex/7f04c4cc-314b-49f4-a49b-a9c95ac78eaa.vsidx
-/.gitignore
-/.vs/bizhawk-shuffler-2-phiggle-fork/FileContentIndex
-/.vs/bizhawk-shuffler-2-phiggle-fork/FileContentIndex/d1105c60-ccf0-4860-b3ae-217ac7d99b9b.vsidx
-/.vs/bizhawk-shuffler-2-phiggle-fork/v17
-/.vs/bizhawk-shuffler-2-phiggle-fork/v17/.wsuo
-/.vs/bizhawk-shuffler-2-phiggle-fork/v17/DocumentLayout.backup.json
-/.vs/bizhawk-shuffler-2-phiggle-fork/v17/DocumentLayout.json
-/.vs/slnx.sqlite
-/.vs/VSWorkspaceState.json
-/.gitignore
-/.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,15 @@ luac.out
 
 # Editor settings
 .vscode/
+/.vs/bizhawk-shuffler-2-phiggle-fork/FileContentIndex/7f04c4cc-314b-49f4-a49b-a9c95ac78eaa.vsidx
+/.gitignore
+/.vs/bizhawk-shuffler-2-phiggle-fork/FileContentIndex
+/.vs/bizhawk-shuffler-2-phiggle-fork/FileContentIndex/d1105c60-ccf0-4860-b3ae-217ac7d99b9b.vsidx
+/.vs/bizhawk-shuffler-2-phiggle-fork/v17
+/.vs/bizhawk-shuffler-2-phiggle-fork/v17/.wsuo
+/.vs/bizhawk-shuffler-2-phiggle-fork/v17/DocumentLayout.backup.json
+/.vs/bizhawk-shuffler-2-phiggle-fork/v17/DocumentLayout.json
+/.vs/slnx.sqlite
+/.vs/VSWorkspaceState.json
+/.gitignore
+/.gitignore

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -402,3 +402,8 @@ ECF7A986266818933022FD370BB30943         SuperKingKong99_GEN          -- Super K
 2931B872753C6400AC53268CCB77862D         SuperMarioWorldSK_GEN        -- Super Mario World (Squirrel King) (Bootleg)
 7127E7A39DA36EC509280E27C72494A827BB6A5A TarzanLOTJ_SNES              -- Tarzan: Lord of the Jungle (unreleased title)
 DF7CF1157F4D716C14037D68997FBFE5E454FFF9 Titenic_NES                  -- Titenic (Bootleg)
+85D9D0F0 								 ResidentEvil_PS1			  -- Resident Evil, PS1 (NSTC)
+F69C55B0								 ResidentEvil_PS1			  -- Resident Evil Director's Cut, PS1 (NSTC)
+A633EDF8								 ResidentEvil_PS1			  -- Resident Evil Director's Cut - Dual Shock, PS1 (NSTC)
+AC6ED84F								 ResidentEvil_PS1			  -- Resident Evil True Director's Cut, PS1 (Original OST 0.4v) (NSTC)
+26DA97D8								 ResidentEvil_PS1			  -- Resident Evil True Director's Cut, PS1 (Dualshock OST 0.3.5.7v) (NSTC)


### PR DESCRIPTION
Added Resident Evil 1 (PSX) to shuffler. Includes OG, Director's Cut, Dualshock and True Director's Cut Hack. All works fine and tested after making sure with hours of playthrough.