### PR TITLE
Add New Super Mario Bros (DS) to shuffler

### DIFF
--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -106,6 +106,7 @@ FAC071FF28CD5D27D0DF465EC124B925C9A5D3D9 SMK_SNES                     -- Super M
 6CF18228CFB66D48B3642069979D4A5103CB8528 SOMARI                       -- Somari NES (unlicensed)
 C807F2856F44FB84326FAC5B462340DCDD0471F8 SMW2YI_SNES                  -- Super Mario World 2 Yoshi's Island SNES (US 1.0)
 34612A93741F156D6E497462AB7F253CB8A959A0 SMW2YI_SNES                  -- Super Mario World 2 Yoshi's Island SNES (US 1.1)
+A2DDBA012E5C3C2096D0BE57CC273BE5         NSMB_DS                      -- New Super Mario Bros DS (US)
 
 -- maybe supported someday, no promises ok?
 -- D8DFACBFEC34CDC871D73C901811551FE1706923 DK1_NES                      -- Donkey Kong NES (WW)


### PR DESCRIPTION
This seems to be working pretty well and only shuffling when it should, so here's *New Soup* for everyone's entertainment.

Has a new `mario_swap` function that may also be extendable to other Mario games in future, based around having a 'status' value rather than a 'health' value causing problems for numerical comparisons.
Status changes caused by deaths still need to be filtered because (damage that results in Small Mario) and (death that results in Small Mario) aren't distinguishable by status value alone.

There was already a commented-out hash in the list, the one added is is the equivalent in MD5 rather than SHA-1 format, as that seems to be what is expected for DS titles.

Tested what I could think of testing, would appreciate confirmation though. If you are testing this, see the game notes for how to set your stored powerup to be able to test the more unusual ones easily.

Holding L+R while selecting your save file lets you play as Luigi, if you're so inclined.