### PR TITLE
Add support for testing single games

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -330,6 +330,9 @@ plugin.description =
 
 local NO_MATCH = 'NONE'
 
+-- debugging settings
+local PAUSE_ON_SWAP = false -- pause whenever a swap would occur
+
 local tags = {}
 local tag
 local gamemeta
@@ -7532,9 +7535,10 @@ if type(tonumber(which_level)) == "number" then
 			debug_timer = -delay
 			swap_game_delay(delay)
 			swap_scheduled = true
-			if not settings.SuppressLog then
+			if not settings.SuppressLog or settings.DebugSingleGame then
 				log_console('Chaos Shuffler: swap scheduled for %s (frame: %d, delay: %d)', tag, frames_since_restart, delay)
 			end
+			if PAUSE_ON_SWAP then client.pause() end
 		end
 	end
 	


### PR DESCRIPTION
Less elaborate than the entire [debug shuffler plugin](https://github.com/kalimag/bizhawk-shuffler-2/blob/feat/damage-shuffler-debugger/plugins/damage-debug.lua) (that I wasn't aware of at the time), but works inline with all the existing games and functions, and may also be useful for testing Infinite* Lives support.

At present, it is required to run multiple games in the shuffler for the swapping logic to function, even if you only want to run a single game for testing. This is because once a swap has been triggered, the shuffler will not allow further swaps until after the first has taken effect. With only one game, this will never happen because the 'parent' shuffler will not reload a game if it is currently running:
https://github.com/Phiggle/bizhawk-shuffler-2/blob/03bfefa2b93ea5974ea8f4852492a6da1c20f13d/shuffler.lua#L402-L408
and so the `swap_scheduled` flag is never cleared by `on_game_load`.

To resove this, this PR adds a (default off) setting, `DebugSingleGame`, that 'rearms' our shuffler logic even if a new game was not loaded (and thus, no `on_game_load` call occurred). This aims to match the 'real' timings as closely as easily possible, allowing for the swap delay and grace period before another swap can be triggered. Once 'rearmed', the shuffler will behave as if you had swapped to and from a different game, allowing further swaps and making single-game testing possible.

Also, if log output hasn't been disabled, this logs each time a swap is scheduled to occur, with the game tag and timing information. As the game won't actually change if you only have one, this is needed to see if/how often swaps are happening, but as it may also be useful for other purposes it's not restricted to the `DebugSingleGame` setting.