### PR TITLE
Clean up some delay handling

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -620,8 +620,11 @@ local function singleplayer_withlives_swap(gamemeta)
 		end
 
 		-- sometimes you want to swap for things that don't take standard health or lives, like non-standard game overs
-		if gamemeta.other_swaps and gamemeta.other_swaps() then
-			data.p1hpcountdown = gamemeta.delay or 3
+		if gamemeta.other_swaps then
+			local swap, delay = gamemeta.other_swaps()
+			if swap then
+				data.p1hpcountdown = delay or gamemeta.delay or 3
+			end
 		end
 		
 		return false
@@ -813,9 +816,12 @@ local function twoplayers_withlives_swap(gamemeta)
 		end
 
 		-- sometimes you want to swap for things that don't take standard health or lives, like non-standard game overs
-		if gamemeta.other_swaps and gamemeta.other_swaps() then
-			data.p1hpcountdown = gamemeta.delay or 3
-			data.p2hpcountdown = gamemeta.delay or 3
+		if gamemeta.other_swaps then
+			local swap, delay = gamemeta.other_swaps()
+			if swap then
+				data.p1hpcountdown = delay or gamemeta.delay or 3
+				data.p2hpcountdown = delay or gamemeta.delay or 3
+			end
 		end
 
 		return false
@@ -1446,16 +1452,6 @@ local function iframe_health_swap(gamemeta)
 	return function(data)
 		local iframes_changed, iframes_curr, iframes_prev = update_prev('iframes', gamemeta.get_iframes())
 		local health_changed, health_curr, health_prev = false, 0, 0
-		-- If a swap is already scheduled, decrease it but do no further processing.
-		if data.delayCountdown ~= nil and data.delayCountdown > 0 then
-			--console.log("delayCountdown: "..data.delayCountdown);
-			data.delayCountdown = data.delayCountdown - 1
-			if data.delayCountdown == 0 then
-				--console.log("delayCountdown is 0; swapping");
-				return true;
-			end
-			return false;
-		end
 		if gamemeta.get_health then
 			health_changed, health_curr, health_prev = update_prev('health', gamemeta.get_health())
 		end
@@ -1476,14 +1472,15 @@ local function iframe_health_swap(gamemeta)
 		if gamemeta.get_health then
 			-- check 0 health for games that don't set iframes on death
 			if (iframes_valid or health_curr == 0) and health_changed and health_curr < health_prev then
-				data.delayCountdown = gamemeta.delay or 3
+				return true, gamemeta.delay
 			end
 		elseif iframes_valid then
-			data.delayCountdown = gamemeta.delay or 3
+			return true, gamemeta.delay
 		end
 		-- sometimes you want to swap for things that don't give iframes and change health, like non-standard game overs
-		if gamemeta.other_swaps() then
-			data.delayCountdown = gamemeta.delay or 3
+		if gamemeta.other_swaps then
+			local swap, delay = gamemeta.other_swaps()
+			return swap, delay or gamemeta.delay
 		end
 	end
 end
@@ -1496,26 +1493,17 @@ local function health_swap(gamemeta)
 		end
 		-- for games where iframes are unhelpful
 		local health_changed, health_curr, health_prev = update_prev('health', gamemeta.get_health())
-		-- If a swap is already scheduled, decrease it but do no further processing.
-		if data.delayCountdown ~= nil and data.delayCountdown > 0 then
-			--console.log("delayCountdown: "..data.delayCountdown);
-			data.delayCountdown = data.delayCountdown - 1
-			if data.delayCountdown == 0 then
-				--console.log("delayCountdown is 0; swapping");
-				return true;
-			end
-			return false;
-		end
 		-- check if we're in a valid gamestate
 		if not gamemeta.is_valid_gamestate() then
 			return false
 		end
 		if health_changed and health_curr < health_prev then
-			data.delayCountdown = gamemeta.delay or 3
+			return true, gamemeta.delay
 		end
 		-- sometimes you want to swap for things that don't reduce health
-		if gamemeta.other_swaps() then
-			data.delayCountdown = gamemeta.delay or 3
+		if gamemeta.other_swaps then
+			local swap, delay = gamemeta.other_swaps()
+			return swap, delay or gamemeta.delay
 		end
 	end
 end
@@ -1562,16 +1550,6 @@ local function jonathan_charlotte_swap(gamemeta)
 		local j_iframes_changed, j_iframes_curr, j_iframes_prev = update_prev('jonathan iframes', gamemeta.get_jonathan_iframes())
 		local c_iframes_changed, c_iframes_curr, c_iframes_prev = update_prev('charlotte iframes', gamemeta.get_charlotte_iframes())
 		local health_changed, health_curr, health_prev = update_prev('health', gamemeta.get_health())
-		-- If a swap is already scheduled, decrease it but do no further processing.
-		if data.delayCountdown ~= nil and data.delayCountdown > 0 then
-			--console.log("delayCountdown: "..data.delayCountdown);
-			data.delayCountdown = data.delayCountdown - 1
-			if data.delayCountdown == 0 then
-				--console.log("delayCountdown is 0; swapping");
-				return true;
-			end
-			return false;
-		end
 		if not gamemeta.is_valid_gamestate() then
 			return false
 		end
@@ -1580,12 +1558,12 @@ local function jonathan_charlotte_swap(gamemeta)
 			and health_changed and health_curr < health_prev
 		then
 			-- jonathan!
-			data.delayCountdown = gamemeta.delay or 3
+			return true, gamemeta.delay
 		elseif not gamemeta.is_jonathan() and c_iframes_changed and c_iframes_prev <= 1
 			and health_changed and health_curr < health_prev
 		then
 			-- charlotte!
-			data.delayCountdown = gamemeta.delay or 3
+			return true, gamemeta.delay
 		end
 	end
 end
@@ -1595,27 +1573,18 @@ local function damage_buffer_swap(gamemeta)
 		-- games that instead of decreasing health directly, set a "damage buffer" value that then decreases health per frame
 		local iframes_changed, iframes_curr, iframes_prev = update_prev('iframes', gamemeta.get_iframes())
 		local buffer_changed, buffer_curr, buffer_prev = update_prev('damage buffer', gamemeta.get_damage_buffer())
-		-- If a swap is already scheduled, decrease it but do no further processing.
-		if data.delayCountdown ~= nil and data.delayCountdown > 0 then
-			--console.log("delayCountdown: "..data.delayCountdown);
-			data.delayCountdown = data.delayCountdown - 1
-			if data.delayCountdown == 0 then
-				--console.log("delayCountdown is 0; swapping");
-				return true;
-			end
-			return false;
-		end
 		if not gamemeta.is_valid_gamestate() then
 			return false
 		end
 		if iframes_changed and iframes_prev == 0 and buffer_changed and buffer_curr > buffer_prev then
 			-- if the buffer is very large, it may not hit 0 before iframes run out
 			-- will this ever actually happen in practice? maybe not, but may as well future-proof this
-			data.delayCountdown = gamemeta.delay or 3
+			return true, gamemeta.delay
 		end
 		-- sometimes you want to swap for things that don't reduce health
-		if gamemeta.other_swaps() then
-			data.delayCountdown = gamemeta.delay or 3
+		if gamemeta.other_swaps then
+			local swap, delay = gamemeta.other_swaps()
+			return swap, delay or gamemeta.delay
 		end
 	end
 end
@@ -1732,16 +1701,6 @@ end
 
 local function Pebble_Beach_Golf_Links_swap(gamemeta)
 	return function(data)
-		-- If a swap is already scheduled, decrease it but do no further processing.
-		if data.delayCountdown ~= nil and data.delayCountdown > 0 then
-			--console.log("delayCountdown: "..data.delayCountdown);
-			data.delayCountdown = data.delayCountdown - 1
-			if data.delayCountdown == 0 then
-				--console.log("delayCountdown is 0; swapping");
-				return true;
-			end
-			return false;
-		end
 
 --		local currentPlayerChanged, currentPlayer, previousPlayer = update_prev('player', gamemeta.getCurrentPlayer());
 --		local player1Changed, player1, prevPlayer1 = update_prev('player1', gamemeta.getPlayer1());
@@ -1751,7 +1710,7 @@ local function Pebble_Beach_Golf_Links_swap(gamemeta)
 --			console.log(string.format("Current player changed from \"%s\" to \"%s\"", previousPlayer, currentPlayer));
 --			if (previousPlayer == prevPlayer1) then
 --				console.log(string.format("Previous player \"%s\" was Player 1 (\"%s\"); will be swapping", previousPlayer, prevPlayer1));
---				data.delayCountdown = gamemeta.delay;
+--				return true, gamemeta.delay;
 --			else
 --				console.log(string.format("Previous player \"%s\" was NOT Player 1 (\"%s\"); no swap needed", previousPlayer, prevPlayer1));
 --			end;
@@ -1780,7 +1739,7 @@ local function Pebble_Beach_Golf_Links_swap(gamemeta)
 			--console.log("P1 Strokes on hole "..hole.." has changed from "..prevPlayer1Strokes.." to "..player1Strokes);
 		end
 		if (player1StrokesChanged and player1Strokes == (prevPlayer1Strokes + 1)) then
-			data.delayCountdown = gamemeta.delay;
+			return true, gamemeta.delay;
 		end
 	end
 end
@@ -1799,16 +1758,6 @@ local function NBA_Jam_swap(gamemeta)
 			--console.log(string.format("Quarter went from %d to %d; swapping", prevQuarter, quarter));
 			return true;
 		end
-		-- If a swap is already scheduled, decrease it but do no further processing.
-		if data.delayCountdown ~= nil and data.delayCountdown > 0 then
-			--console.log("delayCountdown: "..data.delayCountdown);
-			data.delayCountdown = data.delayCountdown - 1
-			if data.delayCountdown == 0 then
-				--console.log("delayCountdown is 0; swapping");
-				return true;
-			end
-			return false;
-		end
 		-- Don't do any further processing if the game mode is wrong.
 		if (gamemeta.gmode and not gamemeta.gmode()) then
 			return false;
@@ -1816,13 +1765,13 @@ local function NBA_Jam_swap(gamemeta)
 		-- If opposing team score went up, swap after a delay
 		if (opposingTeamScoreChanged and opposingTeamScore > prevOpposingTeamScore) then
 			--console.log(string.format("Opposing team score went from %d to %d; swapping in %d frames", prevOpposingTeamScore, opposingTeamScore, gamemeta.delay));
-			data.delayCountdown = gamemeta.delay;
+			return true, gamemeta.delay;
 		end
 		-- If "SHOT CLOCK VIOLATION" is flashing on-screen and the player's team had the ball, swap after a delay
 		if (shotClockViolationMessageTimerChanged and shotClockViolationMessageTimer > prevShotClockViolationMessageTimer) then
 			if (teamWithBall == 0 or (teamWithBall == -1 and teamWithBallChanged and prevTeamWithBall == 0)) then
 				--console.log(string.format("Player held the ball too long without shooting; swapping in %d frames", gamemeta.delay));
-				data.delayCountdown = gamemeta.delay;
+				return true, gamemeta.delay;
 			end
 		end
 	end

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -2257,16 +2257,8 @@ local function TecmoSuperBowl_NES_swap(gamemeta)
 			data.p1_injured_music_cued = false
 		end
 		
-		-- we need to implement a delay for certain swaps, so we will add a countdown here
-		if data.delayCountdown ~= nil and data.delayCountdown > 0 then
-			--console.log("delayCountdown: "..data.delayCountdown);
-			data.delayCountdown = data.delayCountdown - 1
-			if data.delayCountdown == 0 then
-				--console.log("delayCountdown is 0; swapping");
-				return true;
-			end
-			return false;
-		end
+		-- we need to implement a delay for certain swaps
+		local swap_delay = nil
 		
 		-- SWAPS
 		-- first, swap on p2 scoring a TD or FG, after a 60-frame delay
@@ -2278,13 +2270,13 @@ local function TecmoSuperBowl_NES_swap(gamemeta)
 		if data.p2_scored == true and 
 			((p2_kickoff_curr == true and p2_kickoff_prev == false) or (p1_kickoff_curr == true and p1_kickoff_prev == false)) -- latter will handle kickoffs back to p2 after halftime if p2 to end 2Q and gets possession to start Q3
 		then
-			data.delayCountdown = 3
+			swap_delay = 3
 			data.p2_scored = false
 		end
 		-- We need to shuffle if p2 wins the game.
 		if gamemeta.get_end_of_game() == true and p2_points_curr > p1_points_curr
 		then
-			data.delayCountdown = 169 -- wait for scoreboard
+			swap_delay = 169 -- wait for scoreboard
 		end
 		-- We need to shuffle if a p1 player gets injured. We'll know because the music (0x2B) played.
 		-- conveniently, music and sound cues only last for one frame
@@ -2292,13 +2284,13 @@ local function TecmoSuperBowl_NES_swap(gamemeta)
 		-- When the cue goes through to silence the music (0x01), swap
 		if music_cue_curr == 0x01 and data.p1_injured_music_cued == true
 		then
-			data.delayCountdown = 3
+			swap_delay = 3
 		end
 		-- next, swap on possession losses by checking if possession changed to p2 ("p1 now has ball" is irrelevant here)
 		if p1_possession_curr == false and p1_possession_prev == true then
 			-- compare p1's score before and after the possession change (the only time we would not swap right away is if p1 scored and is kicking off)
 			if p1_points_curr == data.p1_score_on_load then -- p1 gave up the ball and didn't score? swap now
-				data.delayCountdown = 3
+				swap_delay = 3
 			else -- p1 is kicking off after a score? update that stored score, and reset "play picker seen" to 0 because it's about to be a new drive for p2
 				data.p1_score_on_load = p1_points_curr
 				data.play_picker_seen = 0
@@ -2307,17 +2299,18 @@ local function TecmoSuperBowl_NES_swap(gamemeta)
 		-- now that we've handled possession changes, we need to check mid-drive failures (p1 doesn't get a first down, or p2 gets one)
 		if picking_play_curr == true and picking_play_prev == false then -- down just changed if the playbook screen just came up
 			if p1_possession_curr and whatdown_curr > data.down_at_start_of_play then -- did down just go up? oh, then you didn't get a first down, huh? swap now
-				data.delayCountdown = 3
+				swap_delay = 3
 			-- next, we need to swap if the opponent has earned a first down - this would happen after the play picker has been seen at least once
 			elseif p1_possession_curr == false and whatdown_curr == 0 and -- it's p2's ball and first down?
 				picking_play_curr == true and picking_play_prev == false and data.play_picker_seen > 0 then -- and the play picker just showed up, and we've seen them pick a play already? swap now
-				data.delayCountdown = 3
+				swap_delay = 3
 			-- and, if none of that is true, update the down we saw the last time the play picker came up
 			else
 				data.down_at_start_of_play = whatdown_curr
 			end
 		end
 		
+		return swap_delay ~= nil, swap_delay
     end
 end
 


### PR DESCRIPTION
Firstly, this cleans up the code which implements its own countdown for delayed swapping to simply use the existing delay support instead, provided the countdown isn't altered once set. This applies to the "health-based" family of swap functions, but not the "with lives" family of functions, which have a variable-length delay and may also choose to defer to lives for swapping during that period.

Secondly, `other_swaps` is updated, both to be optional for the original swap functions using it, and also to allow returning custom delay values for the swap conditions it handles. This is actually already 'used' by a couple of games, such as the GBA Metroids and Majora's Mask, which will now start working as perhaps originally intended.

---

Later, but not in the scope of this PR, is the question of whether to make the delay handling more like how grace is, with per-game default values being handled in `plugin.on_frame` rather than in each swap function. There could also be a user-specified global default `delay` value to use, also like `grace`, with an override hierarchy of (swap overrides > main swap function > game default > user setting default > hardcoded default) so that the most specific value would take effect.
This would allow more customisation and doesn't rely on every swap function choosing to support `gamemeta.delay`, but existing swap functions would need to be revisited to ensure they aren't relying on the current default delay always being short - the "with lives" swap functions are the obvious cases, but there may be others.

