### PR TITLE
Fix HP countdown timers being broken by swap overrides

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -586,6 +586,15 @@ local function singleplayer_withlives_swap(gamemeta)
 			return false
 		end
 
+		-- this delay ensures that when the game ticks away health for the end of a level,
+		-- we can catch its purpose and hopefully not swap, since this isnt damage related
+		if data.p1hpcountdown ~= nil and data.p1hpcountdown > 0 then
+			data.p1hpcountdown = data.p1hpcountdown - 1
+			if data.p1hpcountdown == 0 and p1currhp > minhp then
+				return true
+			end
+		end
+		
 		-- retrieve previous health and lives before backup
 		local p1prevhp = data.p1prevhp
 		local p1prevlc = data.p1prevlc
@@ -604,15 +613,6 @@ local function singleplayer_withlives_swap(gamemeta)
 		-- If a method is provided for swap_exceptions and its conditions are true, process the hp and lives but don't swap.
 		if gamemeta.swap_exceptions and gamemeta.swap_exceptions(gamemeta) then
 			return false
-		end
-		
-		-- this delay ensures that when the game ticks away health for the end of a level,
-		-- we can catch its purpose and hopefully not swap, since this isnt damage related
-		if data.p1hpcountdown ~= nil and data.p1hpcountdown > 0 then
-			data.p1hpcountdown = data.p1hpcountdown - 1
-			if data.p1hpcountdown == 0 and p1currhp > minhp then
-				return true
-			end
 		end
 		
 		-- if the health goes to 0, we will rely on the life count to tell us whether to swap
@@ -760,6 +760,22 @@ local function twoplayers_withlives_swap(gamemeta)
 			return false
 		end
 
+		-- this delay ensures that when the game ticks away health for the end of a level,
+		-- we can catch its purpose and hopefully not swap, since this isnt damage related
+		if data.p1hpcountdown ~= nil and data.p1hpcountdown > 0 then
+			data.p1hpcountdown = data.p1hpcountdown - 1
+			if data.p1hpcountdown == 0 and p1currhp > minhp then
+				return true
+			end
+		end
+
+		if data.p2hpcountdown ~= nil and data.p2hpcountdown > 0 then
+			data.p2hpcountdown = data.p2hpcountdown - 1
+			if data.p2hpcountdown == 0 and p2currhp > minhp then
+				return true
+			end
+		end
+
 		-- retrieve previous health and lives before backup
 		local p1prevhp = data.p1prevhp
 		local p1prevlc = data.p1prevlc
@@ -783,22 +799,6 @@ local function twoplayers_withlives_swap(gamemeta)
 		-- If a method is provided for swap_exceptions and its conditions are true, process the hp and lives but don't swap.
 		if gamemeta.swap_exceptions and gamemeta.swap_exceptions(gamemeta) then
 			return false
-		end
-
-		-- this delay ensures that when the game ticks away health for the end of a level,
-		-- we can catch its purpose and hopefully not swap, since this isnt damage related
-		if data.p1hpcountdown ~= nil and data.p1hpcountdown > 0 then
-			data.p1hpcountdown = data.p1hpcountdown - 1
-			if data.p1hpcountdown == 0 and p1currhp > minhp then
-				return true
-			end
-		end
-
-		if data.p2hpcountdown ~= nil and data.p2hpcountdown > 0 then
-			data.p2hpcountdown = data.p2hpcountdown - 1
-			if data.p2hpcountdown == 0 and p2currhp > minhp then
-				return true
-			end
 		end
 
 		-- if the health goes to 0, we will rely on the life count to tell us whether to swap


### PR DESCRIPTION
Fixes `singleplayer_withlives_swap` and `twoplayers_withlives_swap` to process the "hp countdown" before calling swap overrides instead of after.

The "with lives" functions have a countdown before swapping on health changes. This is controlled by `delay` and waits for the health value to stabilise before committing to a swap. If the health value settles on `minhp`, the swap is deferred to the lives check instead.

Currently, `swap_exceptions` and the value from `gettogglecheck` are checked first, and then the countdown is updated. This creates an issue: the countdown is set by damage that is checked and found to be valid, but any later "invalid damage" that occurs while the countdown is active breaks the countdown and prevents the swap _even though the "invalid damage" was not the damage the countdown was set for in the first place_.

This was probably not noticed more because the default `delay` only leaves a tiny window for issues to occur in, however, with larger `delay` values or certain kinds of checks it becomes much more serious. While it is mildly amusing to entertain the idea of being able to 'perfect parry' a shuffle I do really think this needs fixing.

As a simple example, consider a hypothetical game which has lives, but also some Metroid-style environmental damage. As lives are involved, you might think to use `singleplayer_withlives_swap` along with `swap_exceptions` to add a check to reject damage that doesn't cause iframes. This doesn't work at present - you'll likely find that the game would never shuffle at all. Damage will get through the iframes check, but then at the actual time to shuffle, the iframes check will be failed and nothing will happen.

This resolves this issue by moving the countdown to run before the swap override checks. The initial setting of the countdown will still run after the overrides so any invalid damage will still be blocked as before, however invalid health changes will no longer overwrite valid ones. Also note that if the countdown value is not 0, execution will still pass through to the rest of the function so there will be no change in behaviour other than the countdown being allowed to progress.

The following swap functions aren't changed by this PR - they are all single-game swaps with no general overrides:
```
SMZ3_swap
SMAS_swap
sdbnes_swap
Rocket_Knight_Adventures_swap
```

For reference, these are the current game tags that have a functional `swap_exceptions` definition:
```
BT_SNES
ACTRAISER_SNES
KabukiQuantumFighter_NES
SuperGnG_SNES
ContraHardCorps_GEN
KirbyNightmareDreamland_GBA
LionKing_SNES
PockyRocky_SNES
StreetsOfRage2_GEN
TMNT3_NES
TMNT4_SNES
ShaqFu_GEN
MarioKartSuperCircuit_GBA
```
I looked through all of these and didn't see anything that would be negatively affected by this change - in a couple of cases it looks like it may fix rare "missed swap" issues and in general the implementations all act on the idea that they're handling the current state only, not the state (some timer frames ago) as well.