### PR TITLE
Add Scurge: Hive (GBA, DS) to shuffler

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -6045,6 +6045,7 @@ local gamedata = {
 		is_valid_gamestate = function() return memory.read_u8(0x14F8C, "EWRAM") == 1 end,
 		other_swaps = function() return false end,
 		grace = 90,
+		grace_on_hit = true,
 		-- OTHER NOTES:
 		-- 60 iframes on hit by default, (poison, infection, etc) damage gives none
 		-- health value is 25 on startup, but not valid (8500) on the title screen
@@ -6065,6 +6066,7 @@ local gamedata = {
 		is_valid_gamestate = function() return memory.read_u8(0x0EEA4C, "Main RAM") == 1 end,
 		other_swaps = function() return false end,
 		grace = 90,
+		grace_on_hit = true,
 		-- OTHER NOTES:
 		-- generally the same as the GBA version but with different memory addresses
 		-- maxhp is 0x0EEA14, same notes

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -238,6 +238,7 @@ plugin.description =
 	-Rubble Saver II (GB), 1p
 	-Sanrio World Smash Ball! (SNES), 1-2p
 	-Saturday Night Slam Masters (SNES), 1p
+	-Scurge: Hive (GBA, DS), 1p
 	-SD Gundam Sangokushi Rainbow Tairiku Senki (Japan) (Arcade), 1p
 	-Shaq-Fu (Genesis/Mega Drive), 1p
 	-Shatterhand (NES), 1p
@@ -6035,6 +6036,42 @@ local gamedata = {
 		p1livesaddr=function() return 0x00b6 end,
 		maxlives=function() return 9 end,
 		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['Scurge_GBA'] = { -- Scurge: Hive, GBA
+		func = iframe_health_swap,
+		get_iframes = function() return memory.read_u16_le(0x50E0, "IWRAM") end,
+		get_health = function() return memory.read_u16_le(0xB704, "EWRAM") end,
+		-- needed to filter quitting which sets health to zero (so no iframe checks)
+		is_valid_gamestate = function() return memory.read_u8(0x14F8C, "EWRAM") == 1 end,
+		other_swaps = function() return false end,
+		grace = 90,
+		-- OTHER NOTES:
+		-- 60 iframes on hit by default, (poison, infection, etc) damage gives none
+		-- health value is 25 on startup, but not valid (8500) on the title screen
+		-- max health is visible at 0x14F54 EWRAM, range is 25-999, depends on player level
+		--   this is the display value, sometimes -1, actual value probably just calculated
+		-- infection level is 0x50F5 IWRAM (1-100)
+		-- experience is 0x18FEC EWRAM, 4-byte LE (max level is 66)
+		-- 0x50E4 IWRAM is a non-null pointer while you're grabbed?
+		-- quitting is basically a soft reset that's hard to filter :<
+		--   0x14F8C EWRAM is one of the few values that is actively set before the reset
+		--   set to 0 for this, as well as room transitions and loading, 1 otherwise
+	},
+	['Scurge_DS'] = { -- Scurge: Hive, DS
+		func = iframe_health_swap,
+		get_iframes = function() return memory.read_u16_le(0x1E7D50, "Main RAM") end,
+		get_health = function() return memory.read_u16_le(0x1E9790, "Main RAM") end,
+		-- needed to filter quitting which sets health to zero (so no iframe checks)
+		is_valid_gamestate = function() return memory.read_u8(0x0EEA4C, "Main RAM") == 1 end,
+		other_swaps = function() return false end,
+		grace = 90,
+		-- OTHER NOTES:
+		-- generally the same as the GBA version but with different memory addresses
+		-- maxhp is 0x0EEA14, same notes
+		-- infection level is 0x1E7D65
+		-- experience is 0x1E85E0
+		-- quitting might be easier as max health value gets zeroed out first here
+		--   currently the 0x0EEA4C state filter is the same as on GBA
 	},
 	['ShinobiIII_GEN']={ -- Shinobi III, Genesis
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -446,6 +446,8 @@ ECF9D0BAC130FED7B6A54A67D7B27DF7         Ristar_GEN                   -- Ristar 
 F182EB75F21E46E516CBB6E6BEF0324724BC0F04 SanrioWorldSmashBall_SNES    -- Sanrio World Smash Ball (J)
 CD10C2542DF4579BE57D5033A980DBF6E2C1547E SanrioWorldSmashBall_SNES    -- Sanrio World Smash Ball (J T+Eng1.00 Suicidal)
 DF427B086F61AF56424A0A2FA912C82B2587BCB8 SatNightSlamMasters_SNES     -- Saturday Night Slam Masters (US)
+312304EDD060723EA31979F1F5FA5C66848E29A1 Scurge_GBA                   -- Scurge: Hive, GBA (US)
+1715A66B342D03315E0904B22756BCA3         Scurge_DS                    -- Scurge: Hive, DS (US)
 1FF1CCF826F983E25A2F35F59CF0AC55F3439F09 GundamRainbow_ARC            -- SD Gundam Sangokushi Rainbow Tairiku Senki (Japan)
 72B5848612F80D14BC51807F8C7E239E         ShaqFu_GEN                   -- Shaq-Fu (US)
 611131DDB450C9B46AD6BC53E0C6E26C7140E83E Shatterhand_NES              -- Shatterhand (US)


### PR DESCRIPTION
As per the title, here's the B-tier _isometroid_ that most people probably haven't heard of.

Features both the GBA and DS versions as they're functionally the same game - the DS version has a slightly higher resolution and a bottom-screen map. The GBA version has had a full playthrough of testing, mainly because checking RAM values is easier with the smaller memory, but the DS version has still had memory values and basic mechanics verified and playtested as well.

Includes a fairly generous grace period as swapping in with an enemy projectile onscreen heading towards you can be a common occurance in some places.