### PR TITLE
Add N+ (DS) to shuffler

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -214,6 +214,7 @@ plugin.description =
 	-Mortal Kombat (Genesis/Mega Drive), 1p (for now)
 	-Mortal Kombat II (SNES), 1p (for now)
 	-Mystic Warriors (Arcade), 1p
+	-N+ (DS), 1p
 	-NBA JAM Tournament Edition (PSX), 1p - shuffles on points scored by opponent and on end of quarter
 	-Ninja Gaiden (NES), 1p
 	-Ninja Gaiden II - The Dark Sword of Chaos (NES), 1p
@@ -6090,6 +6091,28 @@ local gamedata = {
 		p1livesaddr=function() return 0x08aa end,
 		maxlives=function() return 69 end,
 		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['NPlus_DS'] = { -- N+, DS
+		func = singleplayer_withlives_swap,
+		p1gethp = function() return 1 end,
+		-- use death counter as 'negative lives'
+		p1getlc = function() return -memory.read_u16_le(0x0DE0D4, "Main RAM") end,
+		maxhp = function() return 1 end,
+		swap_exceptions = function()
+			-- 'gamestate' check, have to actually be playing
+			if memory.read_u32_le(0x0D45A4, "Main RAM") ~= 0 then return true end
+			local restart_pressed = memory.read_u16_le(0x12ECA0, "Main RAM") & 0x400 ~= 0
+			local restart_changed = update_prev('restart', restart_pressed)
+			-- don't swap if 'restart' button was just released (this kills you)
+			if restart_changed and not restart_pressed then return true end
+			-- don't swap after level is finished
+			return memory.read_u8(0x0DE0D9, "Main RAM") == 1
+		end,
+		-- OTHER NOTES:
+		-- 0x0D45A4 is 1 during demos/replays/etc and 0 for 'real' gameplay
+		-- 0x0DE0D9 is 0 during a level, 1 on success, 2 on failure
+		-- 0x0DFF48 is 1 for a frame on death, a frame later for restarts?
+		-- 0x12ECA0 is a bitset of digital inputs (12 bits) (0x400 restart)
 	},
 	['PockyRocky_SNES']={ -- Pocky & Rocky, SNES
 		func=twoplayers_withlives_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -418,6 +418,7 @@ F6AA5291759E982EA249C4B76F729CA2F4AB1CF4 MortalKombatII_SNES          -- Mortal 
 -- 58E4E1259A86FAAADBC982176E569CB2038DBAC5 MortalKombat3_SNES           -- Mortal Kombat III (US)
 5C40F45A495B07A84FBE9C8473155AE0EA55E635 MsPacMan_NES                 -- Ms. Pac Man (Tengen) (US)
 673541B8AE408BBA2B73ABBC7AC7E3A8358F7824 MysticWarriors_ARC           -- Mystic Warriors (Arcade, 2p, US)
+21644DBF43016E80BFF7030B7FAA133C         NPlus_DS                     -- N+ (US)
 18B946459AF12A8D35914A5BFB62AC4CF21F9266 NinjaWarriorsAgain_SNES      -- Ninjawarriors, SNES (USA)
 A0A78631                                 Pepsiman_PSX                 -- Pepsiman (Japan)
 E125E0F65927C7EE16EB71B4C84E0534DC74E9F7 Pictionary_NES               -- Pictionary (US)


### PR DESCRIPTION
I forgot that this game had a DS release, but it's here now for shuffling.

No health or lives, but there's a death counter that works for this.

Currently doesn't swap if you press The Button That Kills You, as this is a deliberate action, however I would generally recommend restarting a level via the pause menu, as on death The Button That Kills You becomes The Button That Sends You Back To The Main Menu and it's easy to lose progress by accident.

In relation to [my comment here](https://github.com/Phiggle/bizhawk-shuffler-2/pull/22#issuecomment-3453981944), this game could do with a short delay on death (20 frames or so), but that can easily be added later if needed.

Played through a little over half of the levels, so I'm hopeful I was able to test all the mechanics.