### PR TITLE
Apply HP checks for damage more consistently

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -585,7 +585,7 @@ local function singleplayer_withlives_swap(gamemeta)
 		end
 		
 		-- if the health goes to 0, we will rely on the life count to tell us whether to swap
-		if p1prevhp ~= nil and p1currhp < p1prevhp then
+		if p1prevhp ~= nil and p1currhp < p1prevhp and p1currhp > minhp and p1currhp < maxhp then
 			data.p1hpcountdown = gamemeta.delay or 3
 		end
 
@@ -771,11 +771,11 @@ local function twoplayers_withlives_swap(gamemeta)
 		end
 
 		-- if the health goes to 0, we will rely on the life count to tell us whether to swap
-		if p1prevhp ~= nil and p1currhp < p1prevhp then
+		if p1prevhp ~= nil and p1currhp < p1prevhp and p1currhp > minhp and p1currhp < maxhp then
 			data.p1hpcountdown = gamemeta.delay or 3
 		end
 		
-		if p2prevhp ~= nil and p2currhp < p2prevhp then
+		if p2prevhp ~= nil and p2currhp < p2prevhp and p2currhp > minhp and p2currhp < maxhp then
 			data.p2hpcountdown = gamemeta.delay or 3
 		end
 


### PR DESCRIPTION
A general principle of the "with lives" swap functions is to avoid double-swapping for damage that also results in a death and thus also deducts a life. This is achieved by checking for a "minimum" HP value and not swapping for that value, as it is assumed that 'genuine' damage that reduces health to that level will also trigger a life loss. `minhp` is expected to be defined around this behaviour.

At the moment, this check for `minhp` is performed here:
https://github.com/Phiggle/bizhawk-shuffler-2/blob/cb5a7ecd7df5b3859ec09afed7cc7eab3261ecb5/plugins/chaos-damage-shuffler.lua#L580-L585

however this is only applied the frame the countdown hits zero.

This means that if HP drops to this value for a shorter period, a swap will happen, even if no lives change occurs (which suggests that the HP drop was not 'real').

With this change the countdown will not be (re)set for any HP drops directly to the `minhp` value. This makes the "waiting for the lives counter" behaviour consistent, without being affected by the timing of later health increases, and avoiding the need for workarounds for false swaps that the existing behaviour causes.

As an example, Battletoads SNES may not need `swap_exceptions` checks with this change.

In addition, health decreases to the current `maxhp` value will now also not set the countdown, as this would be caused by the `maxhp` value decreasing instead of damage. Similarly, this aims to avoid the need for workarounds that currently have to be added for false swaps caused by these `maxhp` changes.

In general, reliable "in gameplay" checks would be the preferred solution for some of these issues, but it's good to be able to avoid ad-hoc workarounds where they aren't actually needed.

It's also worth noting that due to these checks:
https://github.com/Phiggle/bizhawk-shuffler-2/blob/cb5a7ecd7df5b3859ec09afed7cc7eab3261ecb5/plugins/chaos-damage-shuffler.lua#L552-L556

all games using these functions have to have reasonably defined `minhp` and `maxhp` values to work correctly at present, and so shouldn't be negatively affected by the additional checks added here.