### PR TITLE
Add Rhythm Tengoku (GBA) to shuffler

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -232,6 +232,7 @@ plugin.description =
 	-Resident Evil (PSX), 1p - includes OG, Director's Cut, Dualshock and True Director's Cut Hack
 	-Resident Evil 2 (PSX), 1p - includes Regular & DualShock Ver (recommend using multi-disk bundler to work between disks)
 	-Resident Evil 3 (PSX), 1p
+	-Rhythm Tengoku (GBA), 1p
 	-Ristar (Genesis/Mega Drive), 1p
 	-Rock 'n Roll Racing (SNES), 1p
 	-Rocket Knight Adventures (Genesis/Mega Drive), 1p
@@ -6102,6 +6103,33 @@ local gamedata = {
 		p1livesaddr=function() return 0x0022 end,
 		maxlives=function() return 69 end,
 		ActiveP1=function() return true end, -- p1 is always active!	
+	},
+	['RhythmTengoku_GBA'] = { -- Rhythm Tengoku, GBA
+		func = function(gamemeta)
+			return function(data)
+				local score_changed, _, prev_score = update_prev('score', memory.read_s16_le(0x5E, "EWRAM"))
+				-- minigame just finished, score set
+				if score_changed and prev_score < 0 then
+					local ptr = memory.read_u32_le(0x46A4, "IWRAM")
+					if ptr >> 24 == 0x02 then -- EWRAM
+						-- fetch the result: 0 fail, 1 pass, 2 good
+						local grade = memory.read_u8((ptr & 0x3FFFF) + 12, "EWRAM")
+						-- wait for result to show on screen before swapping
+						return grade < gamemeta.target, 150
+					end
+				end
+				return false
+			end
+		end,
+		-- target grade: 1 requires passing, 2 requires a 'good', 3 will always shuffle
+		target = 1,
+		-- OTHER NOTES:
+		-- 0x005E EWRAM holds the score on finishing a minigame, otherwise -1
+		--   values may be 0-1000? grade requirements vary per minigame, not score-based?
+		-- 0x00CE EWRAM holds your overall average rating (0-100?)
+		-- 0x15BC IWRAM shows the music speed (2x BPM?)
+		-- 0x46A4 IWRAM is a pointer to game data
+		--   while on the menu, the selected minigame id is at +0x48
 	},
 	['Ristar_GEN']={ -- Ristar, Genesis
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -444,6 +444,7 @@ DD7A71BF2A14CEC40011A62D2D8C16AC6A23450E ResidentEvil2_PS1_Dualshock  -- Residen
 2FECD1C5                                 ResidentEvil2_PS1_Dualshock  -- Resident Evil 2 DualShock Ver (NTSC) (Leon A Only)
 E0BF0C80                                 ResidentEvil2_PS1_Dualshock  -- Resident Evil 2 DualShock Ver (NTSC) (Claire A Only)
 4C09660B                                 ResidentEvil3_PS1            -- Resident Evil 3, PS1 (NTSC)
+E0AACA45045E408E7E1072BDE5B39278111E1952 RhythmTengoku_GBA            -- Rhythm Tengoku (J, Rev 1)
 ECF9D0BAC130FED7B6A54A67D7B27DF7         Ristar_GEN                   -- Ristar (US)
 49A07665695018B29DEF2CF3F843E10B88889775 RubbleSaverII_GB             -- Rubble Saver II (J)
 F182EB75F21E46E516CBB6E6BEF0324724BC0F04 SanrioWorldSmashBall_SNES    -- Sanrio World Smash Ball (J)


### PR DESCRIPTION
Something a little different, here's the GBA rhythm 'not-quite-WarioWare' game.

As a rhythm game, swapping mid-flow would be very disruptive, so this just potentially swaps at the end of each minigame based on how well the game thinks you did. Each minigame tends to last for around 30-60s, and there are 48 that are graded in this way.

At the moment there's no proper support for settings here (#24), but there's a `target` property in the metadata to handle the requirements for swapping, which can be adjusted to require passing a game, getting a "good" rating, or just swapping after every game regardless. A 'pass' is what's required in-game to unlock more minigames, so this is the current default.

Played through all the minigames testing this and didn't encounter any issues.