### PR TITLE
Add Super Mario Advance 4 (Virtual Console) to shuffler

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -53,6 +53,7 @@ plugin.description =
 	-Super Mario Land (GB or GBC DX patch), 1p
 	-Super Mario Land 2: 6 Golden Coins (GB or GBC DX patch), 1p
 	-Super Mario 64 (N64), 1p - including Better Non-Stop hack
+	-Super Mario Advance 4 (GBA Virtual Console), 1p
 	-New Super Mario Bros. (DS), 1p
 
 	CASTLEVANIA BLOCK
@@ -3346,6 +3347,60 @@ local gamedata = {
 		LivesWhichRAM=function() return "RDRAM" end,
 		maxlives=function() return 69 end,
 		ActiveP1=function() return memory.read_u8(0x33B193, "RDRAM") > 0 end,
+	},
+	['SMA4_VC'] = { -- Super Mario Advance 4 (Virtual Console)
+		func = singleplayer_withlives_swap,
+		p1gethp = function()
+			if memory.read_u8(0x3BB0, "IWRAM") == 1 then
+				return 0 -- maybe a death, wait for lives
+			elseif memory.read_u8(0x2D77, "IWRAM") == 0 then
+				return math.min(memory.read_u8(0x2CE2, "IWRAM"), 2) + 1 -- mario
+			else
+				return math.min(memory.read_u8(0x2CE3, "IWRAM"), 2) + 1 -- luigi
+			end
+		end,
+		p1getlc = function()
+			if memory.read_u8(0x385E, "IWRAM") == 3 then
+				-- e-reader mode lives (shared 1p/2p)
+				return memory.read_s16_le(0x3A48, "IWRAM")
+			else
+				-- 1p + 2p lives, allows for life trading
+				return memory.read_s16_le(0x2A6A, "IWRAM") + memory.read_s16_le(0x2A6C, "IWRAM")
+			end
+		end,
+		maxhp = function() return 3 end,
+		-- only swap for changes during a level
+		swap_exceptions = function() return memory.read_u8(0x376C, "IWRAM") ~= 2 end,
+		-- Infinite* Lives section
+		CanHaveInfiniteLives = true,
+		p1livesaddr = function()
+			if memory.read_u8(0x385E, "IWRAM") == 3 then
+				return 0x3A48
+			elseif memory.read_u8(0x2D77, "IWRAM") == 0 then
+				return 0x2A6A else return 0x2A6C
+			end
+		end,
+		LivesWhichRAM = function() return "IWRAM" end,
+		maxlives = function() return 68 end, -- 1 byte here, so no 420
+		ActiveP1 = function()
+			local state = memory.read_u8(0x376C, "IWRAM")
+			-- lives can be set on map screens as well
+			return state == 1 or state == 2 or state == 10
+		end,
+		-- OTHER NOTES:
+		-- you can have 999 lives in this one for some reason
+		-- 0x376C IWRAM is the overall game state: (for SMB3: 0 title, 1 map, 2 level, 3 bonus)
+		-- 0x385E IWRAM is the SMB3 mode: 0 on title, 1 1p, 2 2p, 3 e-reader
+		--   e-reader mode has its own lives counter
+		-- 0x3BB0 IWRAM is 1 during deaths/end-of-level/mushroom houses
+		--   used to avoid double-swapping on death w/ status > 0
+		-- 0x2C[2E-51] IWRAM is the 1p inventory (36 items), values 1-15 (2p @ 2C[59-7C])
+		-- 0x2CE2/0x2CE3 IWRAM is mario/luigi status: goes (2+) -> 1 -> 0 on hit
+		-- 0x2D77 IWRAM is which character: 0 for mario, 1 for luigi
+		-- 0x2A40 IWRAM is 1 during loading, 0 otherwise
+		-- some game data is stored in a non-fixed location in memory via pointers
+		--   0x7818 and 0x7820 IWRAM appear to hold the start/end pointers for this
+		--   if needed, the actual death status is at +0x62 here: 1 enemy, 2 fall
 	},
 	['NSMB_DS'] = { -- New Super Mario Bros (DS)
 		func = mario_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -109,6 +109,7 @@ FAC071FF28CD5D27D0DF465EC124B925C9A5D3D9 SMK_SNES                     -- Super M
 6CF18228CFB66D48B3642069979D4A5103CB8528 SOMARI                       -- Somari NES (unlicensed)
 C807F2856F44FB84326FAC5B462340DCDD0471F8 SMW2YI_SNES                  -- Super Mario World 2 Yoshi's Island SNES (US 1.0)
 34612A93741F156D6E497462AB7F253CB8A959A0 SMW2YI_SNES                  -- Super Mario World 2 Yoshi's Island SNES (US 1.1)
+DD2879329EC52BD5372F26B75297A67F1A81215A SMA4_VC                      -- Super Mario Advance 4 (US Virtual Console)
 A2DDBA012E5C3C2096D0BE57CC273BE5         NSMB_DS                      -- New Super Mario Bros DS (US)
 
 -- maybe supported someday, no promises ok?


### PR DESCRIPTION
Mostly just for the sake of the e-Reader levels, here's Super Mario Advance 4.

It's important to note that this is just for the Virtual Console versions and not the original GBA releases - the e-Reader support is implemented differently (and there's not much point in this without it).

Supports "two players" to the extent that the game does, which is basically just tracking both Mario and Luigi - otherwise it's really just a single-player game where you can take turns playing if you want.

Implemented using `singleplayer_withlives_swap` instead of `mario_swap` because this has a lot of different powerups which are also very simple health-wise: Small Mario < Big Mario < Fancy Mario. This meant grouping the status values as health was simpler than specifying a damage table like this:

```lua
damage_table = {
	[9] = 1,
	[7] = 1,
	[6] = 1,
	[5] = 1,
	[4] = 1,
	[3] = 1,
	[2] = 1,
	[1] = 0,
},
```

Doesn't shuffle on losing The Boot, both because that's consistent with the NES Mario 3 implementation and also because it's more work.

Played all the world-e levels (not all to completion), as well as both 'Mario' and 'Mario+Luigi' modes in the main game and everything seems to shuffle when it should. For testing, the location of the inventory slots is noted, which use the following IDs:
```
1 mushroom, 2 flower, 3 leaf, 4 frog, 5 tanooki, 6 hammersuit
7 cloud, 8 p-wing, 9 star, 10 anchor, 11 map hammer
12 whistle, 13 music box, 14 feather, 15 boomerang
```

Bonus testing: the game doesn't like it when you enter the world-e gallery while riding a cloud.