### PR TITLE
Allow grace period to be extended on hit

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -13,6 +13,7 @@ plugin.settings =
 	{ name='SMW2YI_MiniBonusSwaps', type='boolean', label="Yoshi's Island: Shuffle on Mini Battle damage/loss", default=true},
 	{ name='IceClimberBonusSwaps', type='boolean', label="Ice Climber (NES): Shuffle on failing the bonus game"},
 	{ name='grace', type='number', label="Minimum grace period before swapping (won't go < 10 frames)", default=10 },
+	{ name='GraceOnHit', type='boolean', label="Apply grace period from last hit instead of last swap" },
 }
 
 plugin.description =
@@ -348,6 +349,7 @@ plugin.description =
 	Suppress Logs: if you do not want the lua console log to tell you about file naming errors, or unrecognized ROMs. This can help keep the log cleaner if you are also using the Mega Man Damage Shuffler or other plugins!
 
 	Grace period: 10 frames is the default minimum frames between swaps. Adjust up as needed. This idea originated in the TownEater fork of the damage shuffler!
+	- This can be adjusted to be 'minimum frames since damage before swapping again' if needed to help with 'combo hits' causing large numbers of swaps.
 
 	Enjoy? Send bug reports?
 
@@ -363,6 +365,7 @@ local tag
 local gamemeta
 local prevdata
 local debug_timer
+local last_hit
 local swap_scheduled
 local shouldSwap
 local gamesleft
@@ -8097,6 +8100,7 @@ end
 function plugin.on_game_load(data, settings)
 	prevdata = {}
 	debug_timer = 0
+	last_hit = 0
 	swap_scheduled = false
 	shouldSwap = function() return false end
 
@@ -8382,14 +8386,13 @@ if type(tonumber(which_level)) == "number" then
 	-- TODO: CAN WE MAKE THIS A FUNCTION AND CALL IT WHEN WE NEED IT
 	
 	-- avoiding super short swaps (<10) as a precaution
-	local grace = math.max(gamemeta and gamemeta.grace or 0, settings.grace, 10)
+	local grace = math.max(gamemeta and gamemeta.grace or 0, settings.grace or 0, 10)
 	
 	if settings.DebugSingleGame and swap_scheduled then
-		debug_timer = debug_timer + 1
-		-- rearm the shuffler even though no on_load happened to reset things
-		if debug_timer > grace then
+		-- rearm the shuffler even though no on_game_load happened to reset things
+		if frames_since_restart - 1 >= debug_timer then
 			prevdata = {}
-			debug_timer = 0
+			last_hit = frames_since_restart - 1
 			swap_scheduled = false
 		end
 	end
@@ -8423,15 +8426,22 @@ if type(tonumber(which_level)) == "number" then
 		
 		-- AND NOW WE SWAP
 		local schedule_swap, delay = shouldSwap(prevdata)
-		if schedule_swap and frames_since_restart > grace then
-			delay = delay or 3
-			debug_timer = -delay
-			swap_game_delay(delay)
-			swap_scheduled = true
-			if not settings.SuppressLog or settings.DebugSingleGame then
-				log_console('Chaos Shuffler: swap scheduled for %s (frame: %d, delay: %d)', tag, frames_since_restart, delay)
+		if schedule_swap then
+			if frames_since_restart > last_hit + grace then
+				delay = delay or 3
+				debug_timer = frames_since_restart + delay
+				swap_game_delay(delay)
+				swap_scheduled = true
+				if not settings.SuppressLog or settings.DebugSingleGame then
+					log_console('Chaos Shuffler: swap scheduled for %s (frame: %d, delay: %d)', tag, frames_since_restart, delay)
+				end
+				if PAUSE_ON_SWAP then client.pause() end
+			else
+				log_debug('Chaos Shuffler: swap blocked (grace) for %s (frame: %d, grace: %d)', tag, frames_since_restart, grace)
+				if settings.GraceOnHit or gamemeta.grace_on_hit then
+					last_hit = frames_since_restart
+				end
 			end
-			if PAUSE_ON_SWAP then client.pause() end
 		end
 	end
 	


### PR DESCRIPTION
Adds the option to apply the grace period as "since last hit" instead of "since last swap", which means that, on swapping in, further swaps won't happen until a continuous period of `grace` frames have passed without any damage being recorded.

This is useful for games where it's possible to recieve "combo" hits which can stretch out past the normal `grace` period, along with situations where you can take continuous damage limited only by iframes (such as some damaging terrain, or being 'inside' an enemy). With this option, as long as the `grace` period covers the gaps between hits, you won't be shuffled again.

This defines both a plugin setting `GraceOnHit` and a game-specific `grace_on_hit` metadata property to specify this behaviour. In keeping with the existing handling of the grace period applying the maximum of the various values, the new behaviour will be enabled if either of these are `true`.

The implementation adds a `last_hit` variable, which starts at 0 and is updated if needed to track non-shuffling hits. The grace period is then adjusted to apply from this time. With the option disabled, `last_hit` remains 0 and so the same `frames_since_restart > grace` logic as before applies. A debug log entry is also added to record hits which don't shuffle due to the grace period.

This also required changing the "debug single games" functionality a little - previously `debug_timer` would wait for both `delay` and `grace` before allowing swaps, now only `delay` will be waited and then the new functionality is used to reapply a `grace` period starting from then.

Names and descriptions are open to tweaking, but I will note that currently https://github.com/authorblues/bizhawk-shuffler-2/issues/89 applies.