### PR TITLE
Add Wario Land 4 (GBA) to shuffler

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -283,6 +283,7 @@ plugin.description =
 	-Ultimate Mortal Kombat 3 (SNES), 1p (for now)
 	-Vice: Project Doom (NES), 1p
 	-Vs. Ice Climber, set IC4-4 B-1 (Arcade), 1p
+	-Wario Land 4 (GBA), 1p
 	-WarioWare, Inc.: Mega Microgame$! (GBA), 1p - bonus games including 2p are pending
 	-Wild Guns (SNES), 1p
 	-Windjammers / Flying Power Disc (Arcade), 1p
@@ -6295,6 +6296,27 @@ local gamedata = {
 			end
 		return false
 		end,
+	},
+	['WarioLand4_GBA'] = { -- Wario Land 4, GBA
+		func = iframe_health_swap,
+		get_iframes = function() return memory.read_u8(0x189C, "IWRAM") end,
+		get_health = function() return memory.read_u8(0x1910, "IWRAM") end,
+		is_valid_gamestate = function() return memory.read_u16_le(0x0C3A, "IWRAM") == 2 end,
+		other_swaps = function()
+			local timer = memory.read_u8(0x0047, "IWRAM")
+			return update_prev('timer', timer) and timer == 10 -- loss due to timer
+		end,
+		-- OTHER NOTES: (addresses in IWRAM unless stated otherwise)
+		-- 1 iframe on hit, remainder given when unstunned
+		-- gamestate at 0x0C3A, subvalue at 0x0C3C
+		-- health countdown at end of level is a copy
+		-- real health is reset on level start (normally to 4)
+		-- state changes to 2 before health is reset (check iframes?)
+		--   otherwise, health is reset in substate 0, filter that?
+		-- timer status hits 4 on time over, ends at 10 (after animations)
+		-- actual timer at 0x0BF0, sparse BCD format (2:45 -> 00 02 04 05)
+		-- total money at 0x0BF4, per-level at 0x0BF8 (stored value * 10)
+		-- medals (shop currency) at 0x0008
 	},
 	['IndianaJonesLC_GEN']={ -- Indiana Jones & The Last Crusade, Genesis
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -491,6 +491,7 @@ D1F36EE7                                 TwistedMetal2_PSX            -- Twisted
 09C094CA1114BCB6D5917E989686CA79B96CF9EA UltimateMortalKombat3_SNES   -- Ultimate Mortal Kombat 3 (USA)
 3E8F1E05F3B0BD08FC1D62FF0EFE81D533B9AF8C ViceProjectDoom_NES          -- Vice: Project Doom (US)
 E4BDA579BA8A08608545F610701A75B6D6D4AC20 VsIceClimber_ARC             -- Vs. Ice Climber, arcade (set IC4-4 B-1)
+B9FE05A8080E124B67BCE6A623234EE3B518A2C1 WarioLand4_GBA               -- Wario Land 4 (US, EU)
 1ECF28D5F3D2E84E3CC58ED621CB0FC0DD9D70D0 WildGuns_SNES                -- Wild Guns (US)
 3324717B142AA4E1BCD4B105521B130F5BCBDEE8 Windjammers_ARC              -- Windjammers / Flying Power Disc
 80A68B09778F80618552E90458B64515A01F6BB7 Wits_NES                     -- Wit's (Japan)


### PR DESCRIPTION
The slightly more conventional Wario Land game.

You have a healthbar in this one, so damage is easier to determine. An iframes check is also included, as health gets reset on starting a new level and this shouldn't count. The timing of these iframes is offset, however you should always get 1 at the moment of damage.

Otherwise, you swap on fully running out of time, which ends the level - there is also the possibility to swap on entering "overtime" for regular levels, which switches to draining the money counter as a second timer, but that's not implemented currently.

Tested through a full normal mode playthrough and a couple of hard mode stages and all seems well.