### PR TITLE
Add Super Monkey Ball: Touch & Roll (DS) to shuffler

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -5439,6 +5439,7 @@ local gamedata = {
 				local gameover = memory.read_u8(0x0C88CB, "Main RAM") == 0
 				return update_prev('gameover', gameover) and gameover, 45
 			end
+			return false
 		end,
 		-- Infinite* Lives section
 		CanHaveInfiniteLives = true,
@@ -5447,6 +5448,7 @@ local gamedata = {
 		maxlives = function() return 69 end,
 		ActiveP1 = function() return memory.read_u32_le(0x0E870C, "Main RAM") == 3 end,
 		-- OTHER NOTES:
+		-- gamestate is at 0x0E870C: 1 title, 2 menus, 3 gameplay, etc
 		-- lives are uncapped, display is mod 100
 		--   practice mode holds lives constant (normally at 99)
 		-- you gameover on failing a level with zero lives

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -260,6 +260,7 @@ plugin.description =
 	-Super Mario Kart (SNES), 1-2p - shuffles on collisions with other karts (lost coins or have 0 coins), falls
 	-Sonic Mario Bros., Squirrel King mechanics (bootleg) (Genesis/Mega Drive), 1p
 	-Super Monkey Ball Jr. (GBA), 1p
+	-Super Monkey Ball: Touch & Roll (DS), 1p
 	-Super Smash TV (SNES), 1p
 	-TaleSpin (NES), 1p
 	-Tarzan: Lord of the Jungle (unreleased) (SNES), 1p
@@ -5425,6 +5426,34 @@ local gamedata = {
 		-- you get 1ups for 50 bananas that doesn't account for that, so 99 is a
 		-- safe compromise. 3 lives max drawn on HUD, but higher values do count
 		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['MonkeyBallTouchRoll_DS'] = { -- Super Monkey Ball: Touch & Roll, DS
+		func = singleplayer_withlives_swap,
+		gmode = function() return memory.read_u32_le(0x0E870C, "Main RAM") == 3 end,
+		p1gethp = function() return 1 end,
+		p1getlc = function() return memory.read_u8(0x1FBF34, "Main RAM") end,
+		maxhp = function() return 1 end,
+		other_swaps = function()
+			if memory.read_u8(0x1FBF34, "Main RAM") == 0 then
+				-- swap for a gameover at zero lives, delay for text to show
+				local gameover = memory.read_u8(0x0C88CB, "Main RAM") == 0
+				return update_prev('gameover', gameover) and gameover, 45
+			end
+		end,
+		-- Infinite* Lives section
+		CanHaveInfiniteLives = true,
+		p1livesaddr = function() return 0x1FBF34 end,
+		LivesWhichRAM = function() return "Main RAM" end,
+		maxlives = function() return 69 end,
+		ActiveP1 = function() return memory.read_u32_le(0x0E870C, "Main RAM") == 3 end,
+		-- OTHER NOTES:
+		-- lives are uncapped, display is mod 100
+		--   practice mode holds lives constant (normally at 99)
+		-- you gameover on failing a level with zero lives
+		--   0x0C88CB goes 1 -> 0 when this happens
+		--   flag also cycles when starting gameplay post-credits,
+		--   however at that point lives should be set > 0
+		-- the banana counter for unlocking world 12 is at 0x1FBF70
 	},
 	['BATMAN_NES']={ -- Batman, NES
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -413,6 +413,7 @@ F569F70DBBEE96A348E053A958120F64F05B7D04 MetalStorm_NES               -- Metal S
 7FA231C5A64B9AF1B4E718B019975B21512A2E51 MetalStorm_NES               -- Metal Storm (US), 3 hit hack
 82FBE365BC96FE3F03C3EB12E1620910B15F01F9 PowerRangersMovie_SNES       -- Mighty Morphin Power Rangers - The Movie (USA)
 B1C7FB96C162BD24751AEC2596BE2D8A         MinnesotaFatsPoolLegend_SAT  -- Minnesota Fats - Pool Legend (R) [Saturn]
+3EB156BBC08451F588865CE3A89A4D08         MonkeyBallTouchRoll_DS       -- Super Monkey Ball: Touch & Roll (US)
 A1DD8A3E4B8C98DEE49D5E90D6B87903         MortalKombat1_GEN            -- Mortal Kombat (US), Genesis
 -- C6DED5B8BCA1716A2DDDFDC697B31F085AAA05D0 MortalKombat_SNES            -- Mortal Kombat (US)
 C312F03638CF09ADED2B662597D4D407C3904764 MortalKombatII_SNES          -- Mortal Kombat II (US)


### PR DESCRIPTION
I found out this also supports the D-Pad, so here it is for shuffling.

Shuffles on losing lives, and on getting a gameover if you don't have unlimited lives turned on. You don't lose lives in bonus stages or in practice mode, so you won't shuffle there. Extra lives are provided by default as there's no continues.

Playtested all 12 worlds in challenge mode, and things seem fine (from a shuffling POV at least, a few stages are kinda rude).