### PR TITLE
Add WarioWare: Twisted! (GBA) to shuffler

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -284,6 +284,7 @@ plugin.description =
 	-Vice: Project Doom (NES), 1p
 	-Vs. Ice Climber, set IC4-4 B-1 (Arcade), 1p
 	-WarioWare, Inc.: Mega Microgame$! (GBA), 1p - bonus games including 2p are pending
+	-WarioWare: Twisted! (GBA), 1p
 	-Wild Guns (SNES), 1p
 	-Windjammers / Flying Power Disc (Arcade), 1p
 	-Wit's (NES), 1p
@@ -5398,6 +5399,31 @@ local gamedata = {
 		CanHaveInfiniteLives=false,
 		-- may add a option for this in the future, but you don't lose *progress* in the story if you game over (similar to Mega Man)
 		-- would also need to consider modes that don't use lives
+	},
+	['WarioWareTwisted_GBA'] = { -- WarioWare: Twisted!, GBA
+		func = singleplayer_withlives_swap,
+		p1gethp = function() return 1 end,
+		p1getlc = function() return memory.read_u8(0x3D86, "IWRAM") end,
+		maxhp = function() return 1 end,
+		-- state check, only swap in gameplay
+		swap_exceptions = function() return memory.read_u16_le(0x3AF4, "IWRAM") ~= 2 end,
+		other_swaps = function()
+			local stage = memory.read_u8(0x3AF8, "IWRAM")
+			if stage == 10 or stage == 15 then -- timed stages
+				local time_up = memory.read_u8(0x4DB4, "IWRAM") == 1
+				return update_prev('time_up', time_up) and time_up, 150
+			end
+			return false
+		end,
+		-- OTHER NOTES:
+		-- 0x3AF4 IWRAM is game state: 1 title, 2 gameplay, 4 main menu, etc
+		-- 0x3AF8 IWRAM is which 'stage': 0-15 for story mode stages, 99+ for bonus/spindex games
+		-- for timed stages: (99 lives, gameover on time up)
+		--   0x4DB0 IWRAM timer: counts 'ticks' with lower byte fractional value (deducted per frame)
+		--     starts at 200 << 8 for 20 'seconds', actual time affected by speedups
+		--     value is soft capped at 300 ticks (won't get bonus time past that)
+		--     snaps to zero on value falling below 256 (1 tick)
+		--   0x4DB4 IWRAM: goes 0 -> 1 on time up, resets after gameover
 	},
 	['MagicalDoropie_NES']={ -- Magical Doropie / Krion Conquest, NES
 		func=iframe_health_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -5411,7 +5411,7 @@ local gamedata = {
 		end,
 		other_swaps = function()
 			local stage = memory.read_u8(0x3AF8, "IWRAM")
-			if stage == 10 or stage == 15 then -- timed stages
+			if stage == 10 or stage == 15 or stage == 99 then -- timed stages
 				local time_up = memory.read_u8(0x4DB4, "IWRAM") == 1
 				return update_prev('time_up', time_up) and time_up, 150
 			end

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -5405,8 +5405,10 @@ local gamedata = {
 		p1gethp = function() return 1 end,
 		p1getlc = function() return memory.read_u8(0x3D86, "IWRAM") end,
 		maxhp = function() return 1 end,
-		-- state check, only swap in gameplay
-		swap_exceptions = function() return memory.read_u16_le(0x3AF4, "IWRAM") ~= 2 end,
+		swap_exceptions = function()
+			return memory.read_u16_le(0x3AF4, "IWRAM") ~= 2 -- state check, only swap in gameplay
+				or memory.read_u8(0x3D86, "IWRAM") == memory.read_u8(0x3D87, "IWRAM") -- at max lives
+		end,
 		other_swaps = function()
 			local stage = memory.read_u8(0x3AF8, "IWRAM")
 			if stage == 10 or stage == 15 then -- timed stages

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -492,6 +492,7 @@ D1F36EE7                                 TwistedMetal2_PSX            -- Twisted
 09C094CA1114BCB6D5917E989686CA79B96CF9EA UltimateMortalKombat3_SNES   -- Ultimate Mortal Kombat 3 (USA)
 3E8F1E05F3B0BD08FC1D62FF0EFE81D533B9AF8C ViceProjectDoom_NES          -- Vice: Project Doom (US)
 E4BDA579BA8A08608545F610701A75B6D6D4AC20 VsIceClimber_ARC             -- Vs. Ice Climber, arcade (set IC4-4 B-1)
+F0102D0D6F7596FE853D5D0A94682718278E083A WarioWareTwisted_GBA         -- WarioWare: Twisted! (US)
 1ECF28D5F3D2E84E3CC58ED621CB0FC0DD9D70D0 WildGuns_SNES                -- Wild Guns (US)
 3324717B142AA4E1BCD4B105521B130F5BCBDEE8 Windjammers_ARC              -- Windjammers / Flying Power Disc
 80A68B09778F80618552E90458B64515A01F6BB7 Wits_NES                     -- Wit's (Japan)


### PR DESCRIPTION
WarioWare returns, this time with motion controls.

Mostly works well with emulated rotation controls using an analog input, however a few microgames work better with different sensitivity settings, so some control adjustments may be needed. Actual motion controls should also be fine if you can get them working with the game.

Swaps on losing lives in the modes that use them and on running out of time in the modes that use a global timer instead.

Played all the story mode stages and a selection of individual bonus/microgames, made a few minor adjustments, and this should now be ready.