### PR TITLE
Add Wario Land GB(C) series to shuffler

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -7226,7 +7226,10 @@ local gamedata = {
 	},
 	['WarioLand1_GB']={ -- Wario Land - Super Mario Land 3 (World)
 		func=singleplayer_withlives_swap,
-		p1gethp=function() return 1 end, -- no health count
+		p1gethp=function()
+			-- powerup state. all damage returns Wario to small form, so for the purpose of damage we only need small and not small
+			return math.min(memory.read_u8(0x080A, "CartRAM"), 1) end,
+		minhp=-1, -- small Wario is value 0, so shuffling needs to occur with health at 0
 		p1getlc=function()
 			--(binary-coded decimal conversation taken from Bubsy Jaguar implementation)
 			-- Need to convert binary-coded decimal hexadecimal value to just plain decimal
@@ -7239,10 +7242,7 @@ local gamedata = {
 			local lives = (tens * 10) + ones
 			return lives end,
 		maxhp=function() return 1 end,
-		other_swaps=function()
-			-- Player can absorb hit when not in small form; swap when player is reduced to small form
-			local form_changed, form_curr, form_prev = update_prev('form', memory.read_u8(0x080A, "CartRAM"))
-			return form_changed and form_curr == 0 end,
+		other_swaps=function() return false end,
 		CanHaveInfiniteLives=true,
 		p1livesaddr=function() return 0x0809 end,
 		LivesWhichRAM=function() return "CartRAM" end,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -283,6 +283,9 @@ plugin.description =
 	-Ultimate Mortal Kombat 3 (SNES), 1p (for now)
 	-Vice: Project Doom (NES), 1p
 	-Vs. Ice Climber, set IC4-4 B-1 (Arcade), 1p
+	-Wario Land - Super Mario Land 3 (World)
+	-Wario Land II (USA, Europe)
+	-Wario Land 3 (World) (En,Ja)
 	-WarioWare, Inc.: Mega Microgame$! (GBA), 1p - bonus games including 2p are pending
 	-Wild Guns (SNES), 1p
 	-Windjammers / Flying Power Disc (Arcade), 1p
@@ -7220,6 +7223,55 @@ local gamedata = {
 		end,
 		grace=80,
 		delay=7,
+	},
+	['WarioLand1_GB']={ -- Wario Land - Super Mario Land 3 (World)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return 1 end, -- no health count
+		p1getlc=function()
+			--(binary-coded decimal conversation taken from Bubsy Jaguar implementation)
+			-- Need to convert binary-coded decimal hexadecimal value to just plain decimal
+			local livesHex = memory.read_u8(0x0809, "CartRAM")
+			-- Get upper nybble, bit-shift right 4 bits
+			local tens = (livesHex & 0xF0)>>4
+			-- Just the lower nybble
+			local ones = livesHex & 0x0F
+			-- Merge 'em
+			local lives = (tens * 10) + ones
+			return lives end,
+		maxhp=function() return 1 end,
+		other_swaps=function()
+			-- Player can absorb hit when not in small form; swap when player is reduced to small form
+			local form_changed, form_curr, form_prev = update_prev('form', memory.read_u8(0x080A, "CartRAM"))
+			return form_changed and form_curr == 0 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x0809 end,
+		LivesWhichRAM=function() return "CartRAM" end,
+		maxlives=function() return 0x69 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['WarioLand2_GBC']={ -- Wario Land II (USA, Europe)
+		func=function() 
+			return function()
+			-- gmode, no shuffling outside of gameplay
+			if memory.read_u8(0x0757, "WRAM")~=85 then return false end
+			
+			-- check iframes value for player being damaged. address starts at 0, goes to 1 when hit, then counts up to some value when the player regains control
+			local iframes_changed, iframes_curr, iframes_prev = update_prev('iframes', memory.read_u8(0x06DC, "WRAM"))
+			
+			-- also check that player is stunned to affirm they were hit by a damaging attack. 
+			-- stun value changes slightly after the iframes value, so we check if the stun has changed in this frame but that the iframes were increased previously
+			local isstunned_changed, isstunned_curr, isstunned_prev = update_prev('isstunned', memory.read_u8(0x0D60, "WRAM")) -- changes to 100 when stunned
+			return isstunned_changed and isstunned_curr == 100 and iframes_curr > 0 end 
+		end,
+	},
+	['WarioLand3_GBC']={ -- Wario Land 3 (World) (En,Ja)
+		func=function() 
+				return function()
+				-- check iframes value for player being damaged. address starts at 0, goes to 1 when hit, then counts up from 16 to some value when the player regains control
+				-- iframes directly go to 16 when iframes are gained from transformation, so by specifically checking change from 0 to 1 we reassure that iframes are from damage
+				local damage_changed, damage_curr, damage_prev = update_prev('damage', memory.read_u8(0x0A8C, "WRAM"))
+				return damage_changed and damage_curr == 1 and damage_prev == 0 end
+			end,
 	},
 	['WildGuns_SNES']={ -- Wild Guns, SNES
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -283,9 +283,9 @@ plugin.description =
 	-Ultimate Mortal Kombat 3 (SNES), 1p (for now)
 	-Vice: Project Doom (NES), 1p
 	-Vs. Ice Climber, set IC4-4 B-1 (Arcade), 1p
-	-Wario Land - Super Mario Land 3 (World)
-	-Wario Land II (USA, Europe)
-	-Wario Land 3 (World) (En,Ja)
+	-Wario Land - Super Mario Land 3 (GB), 1p
+	-Wario Land II (GBC), 1p
+	-Wario Land 3 (GBC), 1p
 	-WarioWare, Inc.: Mega Microgame$! (GBA), 1p - bonus games including 2p are pending
 	-Wild Guns (SNES), 1p
 	-Windjammers / Flying Power Disc (Arcade), 1p

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -492,6 +492,9 @@ D1F36EE7                                 TwistedMetal2_PSX            -- Twisted
 09C094CA1114BCB6D5917E989686CA79B96CF9EA UltimateMortalKombat3_SNES   -- Ultimate Mortal Kombat 3 (USA)
 3E8F1E05F3B0BD08FC1D62FF0EFE81D533B9AF8C ViceProjectDoom_NES          -- Vice: Project Doom (US)
 E4BDA579BA8A08608545F610701A75B6D6D4AC20 VsIceClimber_ARC             -- Vs. Ice Climber, arcade (set IC4-4 B-1)
+AE65800302438E37A99E623A71D1C954D73C843E WarioLand1_GB                -- Wario Land - Super Mario Land 3 (World)
+AE37915058035DF4CEEDD72D709F91EFB4878EFF WarioLand2_GBC               -- Wario Land II (USA, Europe)
+BB7877309834441FD03ADB7FA65738E5D5B2D7BA WarioLand3_GBC               -- Wario Land 3 (World) (En,Ja)
 1ECF28D5F3D2E84E3CC58ED621CB0FC0DD9D70D0 WildGuns_SNES                -- Wild Guns (US)
 3324717B142AA4E1BCD4B105521B130F5BCBDEE8 Windjammers_ARC              -- Windjammers / Flying Power Disc
 80A68B09778F80618552E90458B64515A01F6BB7 Wits_NES                     -- Wit's (Japan)


### PR DESCRIPTION
Adds support for the remaining Wario Land games across the Game Boy and Game Boy Color: Wario Land - Super Mario Land 3, Wario Land II, and Wario Land 3. Wario Land 4 has not been included due to a support already having been worked on by bs2609. None of the games feature a health count.

The original Wario Land - Super Mario Land 3 uses a similar power-up system to the Super Mario Bros. series. Shuffling has been implemented when the player loses a life, and when the player is changed to small Mario form from a large Wario form.

The player can generally not die from attacks in Wario Land 2 and 3. Additionally, both feature temporary transformations that visually appear to be caused by enemy attacks, but are meant for gameplay puzzles and thus gaining and losing them is often unavoidable; it doesn't seem like these should be punished with shuffling. Both are implemented as anonymous functions to account for their distinctive functionality.

Transforming or losing a transformation in Wario Land II may result in iframes. To provide additional assurance that the iframes are related to damage, we are checking for both the increase in iframes and a value associated with the period of stun after receiving damage.

In Wario Land 3, iframes value may momentarily drop to zero between the initial animation played upon receiving damage and the player actually being able to walk around with invincibility. Since the initial damage animation has the value at 1 but the invincibility starts with the value at 16, the shuffle only occurs when the value increases from 0 to 1. This also prevents shuffling from transformations that include iframes due to skipping the damaged animation.


Testing has been limited to the early game.

Potential concern: the final boss of Wario Land 3, Rudy the Clown, is able to cause a game over with his attacks. This scenario has not yet been tested.