### PR TITLE
Add gallery shooters to shuffler

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -149,6 +149,7 @@ plugin.description =
 	-Bucky O'Hare (NES), 1p
 	-Bugs Bunny: Birthday Blowout (NES), 1p
 	-Bugs Bunny: Crazy Castle (NES), 1p
+	-Cabal (NES) (US), 1p
 	-Captain Novolin (SNES), 1p
 	-Chip and Dale Rescue Rangers 1 (NES), 1-2p
 	-Chip and Dale Rescue Rangers 2 (NES), 1-2p
@@ -278,6 +279,7 @@ plugin.description =
 	-Tony Hawk's Pro Skater 2 (PSX), 1p
 	-Tony Hawk's Pro Skater 3 (PSX), 1p
 	-Tony Hawk's Pro Skater 4 (PSX), 1p
+	-Tsumi to Batsu - Hoshi no Keishousha (Japan) / Sin and Punishment (N64), 1p
 	-Twisted Metal 2 (PSX), 1p
 	-U.N. Squadron (SNES), 1p
 	-Ultimate Mortal Kombat 3 (SNES), 1p (for now)
@@ -2633,6 +2635,17 @@ local gamedata = {
 		gmode=function() return (memory.read_u8(0x0070, "RAM")%2) == 0 end,
 		-- several potential values, but if it's ever odd, we're not in-game.
 		maxhp=function() return 60 end,
+	},
+	['Cabal_NES']={ -- Cabal, NES (US)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return 1 end,
+		p1getlc=function() return memory.read_u8(0x00D4, "RAM") - 242 end, -- lives, starts counting with 242 being zero
+		maxhp=function() return 9 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x00D4 end, -- continues respawn the player wherever they died like lives, so giving the player unlimited lives is less cumbersome
+		LivesWhichRAM=function() return "RAM" end,
+		maxlives=function() return 9 + 242 end,
+		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['CaptainNovolin']={ -- Captain Novolin SNES
 		func=singleplayer_withlives_swap,
@@ -7349,6 +7362,24 @@ local gamedata = {
 		maxlives=function() return 10 end, -- one more than displayed
 		ActiveP1=function() return mainmemory.read_u8(0x400) > 0 end,
 		ActiveP2=function() return mainmemory.read_u8(0x500) > 0 end,
+	},
+	['SinAndPunishment_N64']={ -- Tsumi to Batsu - Hoshi no Keishousha (Japan) / Sin and Punishment
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x0D5A9B, "RDRAM") end,
+		p1getlc=function() return memory.read_u8(0x0D5C0F, "RDRAM") end,
+		maxhp=function() return 100 end,
+		minhp=-1,
+		grace=15,
+		swap_exceptions=function() -- player takes 1 damage every second when time is zero, only swap for larger damage when time over
+			local health_changed, health_curr, health_prev = update_prev('health', memory.read_u8(0x0D5A9B, "RDRAM"))
+			local timer_curr = memory.read_u8(0x0D5A97, "RDRAM")
+			return health_changed and timer_curr == 0 and health_curr == (health_prev - 1) end,
+		gmode=function() return memory.read_u8(0x068A92, "RDRAM") == 0 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x0D5C0F end,
+		LivesWhichRAM=function() return "RDRAM" end,
+		maxlives=function() return 69 end,
+		ActiveP1=function() return memory.read_u8(0x068A92, "RDRAM") == 0 end, -- to prevent the game from freezing during startup
 	},
 	['TwistedMetal2_PSX']={ -- Twisted Metal 2, PSX
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -7374,12 +7374,12 @@ local gamedata = {
 			local health_changed, health_curr, health_prev = update_prev('health', memory.read_u8(0x0D5A9B, "RDRAM"))
 			local timer_curr = memory.read_u8(0x0D5A97, "RDRAM")
 			return health_changed and timer_curr == 0 and health_curr == (health_prev - 1) end,
-		gmode=function() return memory.read_u8(0x068A92, "RDRAM") == 0 end,
+		gmode=function() return memory.read_u8(0x075C13, "RDRAM") == 100 end,
 		CanHaveInfiniteLives=true,
 		p1livesaddr=function() return 0x0D5C0F end,
 		LivesWhichRAM=function() return "RDRAM" end,
 		maxlives=function() return 69 end,
-		ActiveP1=function() return memory.read_u8(0x068A92, "RDRAM") == 0 end, -- to prevent the game from freezing during startup
+		ActiveP1=function() return memory.read_u8(0x075C13, "RDRAM") == 100 end, -- to prevent the game from freezing during startup
 	},
 	['TwistedMetal2_PSX']={ -- Twisted Metal 2, PSX
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -149,7 +149,7 @@ plugin.description =
 	-Bucky O'Hare (NES), 1p
 	-Bugs Bunny: Birthday Blowout (NES), 1p
 	-Bugs Bunny: Crazy Castle (NES), 1p
-	-Cabal (NES) (US), 1p
+	-Cabal (NES), 1p
 	-Captain Novolin (SNES), 1p
 	-Chip and Dale Rescue Rangers 1 (NES), 1-2p
 	-Chip and Dale Rescue Rangers 2 (NES), 1-2p
@@ -279,7 +279,7 @@ plugin.description =
 	-Tony Hawk's Pro Skater 2 (PSX), 1p
 	-Tony Hawk's Pro Skater 3 (PSX), 1p
 	-Tony Hawk's Pro Skater 4 (PSX), 1p
-	-Tsumi to Batsu - Hoshi no Keishousha (Japan) / Sin and Punishment (N64), 1p
+	-Tsumi to Batsu - Hoshi no Keishousha / Sin and Punishment (N64), 1p
 	-Twisted Metal 2 (PSX), 1p
 	-U.N. Squadron (SNES), 1p
 	-Ultimate Mortal Kombat 3 (SNES), 1p (for now)

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -233,6 +233,7 @@ E68578447EAA2F711C83244BE4653CC241D38A50 BATMAN_NES                   -- Batman,
 0EDB36400187C445E0389253ABBC31A5603523C4 BladesofSteel_NES            -- Blades of Steel, NES (Europe)
 967E054C94205BDCF97E377D14C41DF55EADB9CA BladesofSteel_NES            -- Blades of Steel, NES (US, 10-minute periods hack)
 9F6FF6264E0361E074F9CFEE2EC4976866A781C5 BUBSY1_SNES                  -- Bubsy in Claws Encounters of the Furred Kind SNES (US)
+2CA85D4D144A9C61BC9E14580B66EBCC68B7DAB9 Cabal_NES                    -- Cabal, NES (US)
 72CFB569819DA4E799BF8FA1A6F023664CC7069B CaptainNovolin               -- Captain Novolin SNES
 39A5FDB7EFD4425A8769FD3073B00DD85F6CD574 CNDRR1_NES                   -- Chip and Dale Rescue Rangers NES (US)
 8F99E72354ED75469290D3F997CFF6C9E393A781 CNDRR1_NES                   -- Chip and Dale Rescue Rangers NES (US) (No Intro Headered)
@@ -325,6 +326,7 @@ D8B1088520F7C5F81433292A9258C1184AFA1457 StarFox64_N64                -- Star Fo
 7A466684F5928FE656841DF20BCB458E74108239 SuperDodgeBall               -- Super Dodge Ball NES (US) (No Intro Headerless)
 0D994A58B7ACDFE9357E5405ACEBE232128B80FE JUNKY_BALL_MR_GBA            -- Super Monkey Ball Jr. (USA)
 A0F16ED356CF99DE2E1B72FB289C9C7FCE8F2AB3 ContraIII_SNES               -- Super Probotector - Alien Rebels (Europe)
+581297B9D5C3A4C33169AE0AAE218C742CD9CBCF SinAndPunishment_N64         -- Tsumi to Batsu - Hoshi no Keishousha (Japan) / Sin and Punishment
 A2DD48574B9F7A49977C91D12D5C52C17C2C82AA UNSquadron_SNES              -- U.N. Squadron (US)
 0F500AB60B7DDB382F70A9EA3FB68E7FC593091C UNSquadron_SNES              -- U.N. Squadron (-grind hack)
 B9E2FCAABC7BB71BEC3B6AD4BA1CD26E2A441A9C UNSquadron_SNES              -- U.N. Squadron (Europe)


### PR DESCRIPTION
Adds single player support for Cabal for the NES, as well as Sin and Punishment (Tsumi to Batsu - Hoshi no Keishousha) for the N64.

Cabal does not feature a health system distinct from its lives and continues. Sin and Punishment features both health and continues.

Note that only single player shuffler support has been added for Cabal, though the game does feature two player co-op.

Cabal's continues are not used for shuffler or infinite lives because continue prompt happens at zero lives and revival after continue is instant, making it unnecessary to treat separately from lives.

Potential issue: If the stage timer in Sin and Punishment is allowed to run out, their health drains continually by about 1 health per second. A swap_exceptions function was added to prevent constant swapping on timer expiry by requiring damage to be greater than 1 to trigger a shuffle while the timer is expired. If attacks dealing only 1 point of damage are found, it may be necessary to add a more specific condition to identify the frame where 1 point of health drain is expected. 0x068258 reaching 200 seems to be the most consistent indicator that I've found. 

A few enemies in Sin and Punishment use machine guns that may cause rapid shuffling; improvements to the grace mechanic to require a minimum period without damage may resolve the issue.


Both games have been tested primarily in the early game.