### PR TITLE
Add King of the Monsters series to shuffler

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -5715,6 +5715,7 @@ local gamedata = {
 		p1gethp=function() return memory.read_u8(0x000993, "68K RAM") end,
 		p1getlc=function() return 2 - memory.read_u8(0x000533, "68K RAM") end, -- p2 rounds won
 		maxhp=function() return 80 end,
+		swap_exceptions=function() return memory.read_u8(0x000933, "68K RAM")==27 end, -- suppress shuffling when player is blocking
 		CanHaveInfiniteLives=true,
 		p1livesaddr=function() return 0x00051D end, -- continues
 		LivesWhichRAM=function() return "68K RAM" end,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -191,9 +191,9 @@ plugin.description =
 	-Jungle Book, The (NES, SNES, Genesis/Mega Drive), 1p
 	-Jurassic Park (SNES), 1p
 	-Kabuki Quantum Fighter (NES), 1p
-	-King of the Monsters, (arcade) (set 1), 1p
-	-King of the Monsters 2 - The Next Thing (NGM-039 ~ NGH-039) (Arcade), 1p
-	-King of the Monsters 2 (U) [!] (Genesis/Mega Drive), 1p
+	-King of the Monsters, (arcade), 1p
+	-King of the Monsters 2 - The Next Thing (Arcade), 1p
+	-King of the Monsters 2 (Genesis/Mega Drive), 1p
 	-Kuru Kuru Kururin (GBA), 1p
 	-Last Alert (TG-16 CD), 1p
 	-Little Samson (NES), 1p

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -191,6 +191,9 @@ plugin.description =
 	-Jungle Book, The (NES, SNES, Genesis/Mega Drive), 1p
 	-Jurassic Park (SNES), 1p
 	-Kabuki Quantum Fighter (NES), 1p
+	-King of the Monsters, (arcade) (set 1), 1p
+	-King of the Monsters 2 - The Next Thing (NGM-039 ~ NGH-039) (Arcade), 1p
+	-King of the Monsters 2 (U) [!] (Genesis/Mega Drive), 1p
 	-Kuru Kuru Kururin (GBA), 1p
 	-Last Alert (TG-16 CD), 1p
 	-Little Samson (NES), 1p
@@ -5655,6 +5658,47 @@ local gamedata = {
 			if (memory.read_u8(0x355, "RAM") == 0x80) then return true end
 			return false
 		end,
+	},
+	['KingOfTheMonsters_ARC']={ -- King of the Monsters, arcade (set 1)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x00206B, "m68000 : ram : 0x100000-0x10FFFF") end,
+		p1getlc=function()
+			--(binary-coded decimal conversation taken from Bubsy Jaguar implementation)
+			-- Need to convert binary-coded decimal hexadecimal value to just plain decimal
+			local livesHex = memory.read_u8(0x000034, "m68000 : ram : 0xD00000-0xD0FFFF")
+			-- Get upper nybble, bit-shift right 4 bits
+			local tens = (livesHex & 0xF0)>>4
+			-- Just the lower nybble
+			local ones = livesHex & 0x0F
+			-- Merge 'em
+			local lives = (tens * 10) + ones
+			return lives end,
+		maxhp=function() return 60 end,
+		gmode=function() return memory.read_u8(0x00005A, "m68000 : ram : 0x100000-0x10FFFF")==48 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+		grace=30,
+	},
+	['KingOfTheMonsters2_ARC']={ -- King of the Monsters 2 - The Next Thing (NGM-039 ~ NGH-039)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x001417, "m68000 : ram : 0x100000-0x10FFFF") end,
+		p1getlc=function() return memory.read_u8(0x0013B8, "m68000 : ram : 0x100000-0x10FFFF") end,
+		maxhp=function() return 64 end,
+		CanHaveInfiniteLives=false, -- infinite lives not provided to enable character switching, coins can't be pushed
+		p1livesaddr=function() return 0x000034 end,
+		LivesWhichRAM=function() return "m68000 : ram : 0xD00000-0xD0FFFF" end,
+		maxlives=function() return 69 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['KingOfTheMonsters2_GEN']={ -- King of the Monsters 2 (U) [!]
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x000993, "68K RAM") end,
+		p1getlc=function() return 2 - memory.read_u8(0x000533, "68K RAM") end, -- p2 rounds won
+		maxhp=function() return 80 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x00051D end, -- continues
+		LivesWhichRAM=function() return "68K RAM" end,
+		maxlives=function() return 69 end,
+		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['GhostsnGoblins_NES']={ -- Ghosts n' Goblins, NES
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -5699,6 +5699,7 @@ local gamedata = {
 		LivesWhichRAM=function() return "68K RAM" end,
 		maxlives=function() return 69 end,
 		ActiveP1=function() return true end, -- p1 is always active!
+		grace=20,
 	},
 	['GhostsnGoblins_NES']={ -- Ghosts n' Goblins, NES
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -5679,15 +5679,36 @@ local gamedata = {
 		grace=30,
 	},
 	['KingOfTheMonsters2_ARC']={ -- King of the Monsters 2 - The Next Thing (NGM-039 ~ NGH-039)
-		func=singleplayer_withlives_swap,
-		p1gethp=function() return memory.read_u8(0x001417, "m68000 : ram : 0x100000-0x10FFFF") end,
-		p1getlc=function() return memory.read_u8(0x0013B8, "m68000 : ram : 0x100000-0x10FFFF") end,
-		maxhp=function() return 64 end,
+		func=function() return function()
+			local health_changed, health_curr, health_prev = update_prev('health', memory.read_u8(0x001417, "m68000 : ram : 0x100000-0x10FFFF"))
+			local lives_changed, lives_curr, lives_prev = update_prev('lives', memory.read_u8(0x0013B8, "m68000 : ram : 0x100000-0x10FFFF"))
+			local credits_changed, credits_curr, credits_prev = update_prev('credits', memory.read_u8(0x000034, "m68000 : ram : 0xD00000-0xD0FFFF"))
+			
+			local gmode = memory.read_u8(0x0013B4, "m68000 : ram : 0x100000-0x10FFFF")==255
+			
+			local maxhp=64
+			
+			if gmode then
+				if health_changed and health_curr > 0 and health_curr <= maxhp then
+					if health_curr < health_prev then return true end
+				end
+				
+				if lives_changed and health_prev == 0 then	
+					if lives_curr == lives_prev - 1 then return true end
+				end
+			
+				if credits_changed and health_prev == 0 and lives_prev == 0 then
+					if credits_curr < credits_prev then return true end
+				end
+			end
+			return false end
+		end,
 		CanHaveInfiniteLives=false, -- infinite lives not provided to enable character switching, coins can't be pushed
-		p1livesaddr=function() return 0x000034 end,
+		p1livesaddr=function() return 0x0013B8 end,
 		LivesWhichRAM=function() return "m68000 : ram : 0xD00000-0xD0FFFF" end,
 		maxlives=function() return 69 end,
 		ActiveP1=function() return true end, -- p1 is always active!
+		grace=30,
 	},
 	['KingOfTheMonsters2_GEN']={ -- King of the Monsters 2 (U) [!]
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -284,6 +284,9 @@ A582DF3B880A0C8DDC1CDA358C96E306C1E222BB FZERO_SNES                   -- F-Zero 
 1690E419BC2435739EFBE59A64D83538FF7E16B4 IceClimber_NES               -- Ice Climber (Japan)
 86C392A1D9A731FA48E148AFBE60AF75F918CB5A Jackal_NES                   -- Jackal NES
 A9338759D653CA7056BD2705D44EAD2C6877ACC1 JamesBondJr_SNES             -- James Bond Jr. (US)
+AFE775A42EE497F8B8DCFD0BA60DA7AC30356FA2 KingOfTheMonsters_ARC        -- King of the Monsters, arcade (set 1)
+F7EBD4A3C559E7FAA9F4EA0EE4E34B47A384A0AF KingOfTheMonsters2_ARC       -- King of the Monsters 2 - The Next Thing (NGM-039 ~ NGH-039) (Arcade)
+65EE5A29E73A4C5C62DA5DA6920ED4D8         KingOfTheMonsters2_GEN       -- King of the Monsters 2 (U) [!]
 E099D688760FF0CE114CA8A9FD083E31E41CFADE KIRBY_NES                    -- Kirby's Adventure NES (US 1.0)
 57F02801D29D3AC1FB9DA7294F0603C43A6F439F KIRBY_NES                    -- Kirby's Adventure NES (US 1.0) (No Intro Headered)
 32473799F96406D73AA37D5CF66E0E27F1F339DA KIRBY_NES                    -- Kirby's Adventure NES (US 1.0) (No Intro Headerless)


### PR DESCRIPTION
Adds single player support for the arcade versions of King of the Monsters and King of the Monsters 2, as well as for the King of the Monsters 2 for Mega Drive/Genesis, which is effectively a separate game from the arcade version.

Note that only single player shuffler support has currently been added, although the arcade versions of King of the Monsters and King of the Monsters 2 both support two player co-op. The Genesis version of King of the Monsters 2 does not support co-op play, so this doesn't apply to that version.

The original King of the Monsters is a wrestling game where the player is defeated by pin, damage serving only to prime that character for the pin. The Genesis version of King of the Monsters 2 resembles the gameplay of the original, but features a fighting game style round system in lieu of pins wherein the player loses the round when their health is depleted. The arcade version of King of the Monsters 2 is a beat em up game featuring standard health and lives systems.

Due to the Genesis version of King of the Monsters 2 using a fighting game styled system, shuffling on death and infinite lives are decoupled. Shuffles are set to occur when the player loses a round, but infinite continues are provided instead of forcing rounds lost to zero.

The original King of the Monsters tends to result in exchanges of jabs; it could benefit from updates to grace mechanic to demand a minimum duration without damage before shuffling.

All three games have been tested primarily in the early game.