### PR TITLE
Add miscellaneous fighting games to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -4156,7 +4156,14 @@ local gamedata = {
 	},
 	['FatalFury1_ARC']={ -- Fatal Fury - King of Fighters / Garou Densetsu - Shukumei no Tatakai (NGM-033 ~ NGH-033)
 		func=health_swap,
-		is_valid_gamestate=function() return memory.read_u8(0x00002A, "m68000 : ram : 0x100000-0x10FFFF")==54 end,
+		is_valid_gamestate=function() 
+			-- player takes chip damage when hit by special attacks while blocking. suppress shuffling when taking chip damage, unless it ko's
+			if memory.read_u8(0x000316, "m68000 : ram : 0x100000-0x10FFFF")==142 -- marks that damage was taken when blocking
+				and memory.read_s8(0x0003B9, "m68000 : ram : 0x100000-0x10FFFF")>0 -- health is above zero
+				then return false end
+		
+			-- gmode
+			return memory.read_u8(0x00002A, "m68000 : ram : 0x100000-0x10FFFF")==54 end,
 		get_health=function() return memory.read_s8(0x0003B9, "m68000 : ram : 0x100000-0x10FFFF") end,
 		other_swaps=function() return false end,
 		grace=30,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -167,7 +167,7 @@ plugin.description =
 	-Einhänder (PSX), 1p
 	-F-Zero (SNES), 1p
 	-Family Feud (SNES), 1-2p
-	-Fatal Fury - King of Fighters / Garou Densetsu - Shukumei no Tatakai (NGM-033 ~ NGH-033) (Arcade), 1p
+	-Fatal Fury - King of Fighters / Garou Densetsu - Shukumei no Tatakai (Arcade), 1p
 	-Garfield: A Week of Garfield (NES), 1p
 	-Gargoyle's Quest II (NES), 1p
 	-Ghosts'n Goblins (NES), 1p
@@ -246,7 +246,7 @@ plugin.description =
 	-Shatterhand (NES), 1p
 	-Shinobi III (Genesis/Mega Drive), 1p
 	-Simpsons: Bart vs. the World (NES), 1p
-	-Slaughter Sport (U) [c][!] (Genesis/Mega Drive), 1p
+	-Slaughter Sport (Genesis/Mega Drive), 1p
 	-Snake Rattle 'n Roll (NES), 1p
 	-Sonic Jam 6 (bootleg) (Genesis/Mega Drive), 1p
 	-Sparkster (SNES), 1p

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -167,6 +167,7 @@ plugin.description =
 	-Einhänder (PSX), 1p
 	-F-Zero (SNES), 1p
 	-Family Feud (SNES), 1-2p
+	-Fatal Fury - King of Fighters / Garou Densetsu - Shukumei no Tatakai (NGM-033 ~ NGH-033) (Arcade), 1p
 	-Garfield: A Week of Garfield (NES), 1p
 	-Gargoyle's Quest II (NES), 1p
 	-Ghosts'n Goblins (NES), 1p
@@ -245,6 +246,7 @@ plugin.description =
 	-Shatterhand (NES), 1p
 	-Shinobi III (Genesis/Mega Drive), 1p
 	-Simpsons: Bart vs. the World (NES), 1p
+	-Slaughter Sport (U) [c][!] (Genesis/Mega Drive), 1p
 	-Snake Rattle 'n Roll (NES), 1p
 	-Sonic Jam 6 (bootleg) (Genesis/Mega Drive), 1p
 	-Sparkster (SNES), 1p
@@ -4152,6 +4154,13 @@ local gamedata = {
 		getwhichplayer=function() return memory.read_u8(0x08DF, "WRAM") end,
 		CanHaveInfiniteLives=false
 	},
+	['FatalFury1_ARC']={ -- Fatal Fury - King of Fighters / Garou Densetsu - Shukumei no Tatakai (NGM-033 ~ NGH-033)
+		func=health_swap,
+		is_valid_gamestate=function() return memory.read_u8(0x00002A, "m68000 : ram : 0x100000-0x10FFFF")==54 end,
+		get_health=function() return memory.read_s8(0x0003B9, "m68000 : ram : 0x100000-0x10FFFF") end,
+		other_swaps=function() return false end,
+		grace=30,
+	},
 	['Monopoly_NES']={ -- Monopoly (NES)
 		func=Monopoly_NES_swap,
 		delay=120, -- higher than normal to help player process reason for swap!
@@ -4404,6 +4413,18 @@ local gamedata = {
 		LivesWhichRAM = function() return "RDRAM" end,
 		maxlives = function() return 9 end,
 		ActiveP1 = function() return true end,
+	},
+	['FatmanSlaughterSport_GEN']={ -- Slaughter Sport (U) [c][!]
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x002895, "68K RAM") end,
+		p1getlc=function() return memory.read_u8(0x002C30, "68K RAM") end,
+		maxhp=function() return 104 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x002C30 end,
+		LivesWhichRAM=function() return "68K RAM" end,
+		maxlives=function() return 3 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+		grace=30,
 	},
 	['SNAKE_RATTLE_N_ROLL_NES']={ -- Snake Rattle 'N' Roll, NES
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -4424,7 +4424,7 @@ local gamedata = {
 		LivesWhichRAM=function() return "68K RAM" end,
 		maxlives=function() return 3 end,
 		ActiveP1=function() return true end, -- p1 is always active!
-		grace=30,
+		grace=40,
 	},
 	['SNAKE_RATTLE_N_ROLL_NES']={ -- Snake Rattle 'N' Roll, NES
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -280,6 +280,7 @@ D3EFD32B68F1FE37A82DB9D9929B7CA7CC1A3AF4 FZERO_SNES                   -- F-Zero 
 A582DF3B880A0C8DDC1CDA358C96E306C1E222BB FZERO_SNES                   -- F-Zero SNES with 3 lap hack
 3F20C2C8749CCEE3A53732B41AE026BF3AAA2158 FamilyFeud_SNES              -- Family Feud SNES (US 1.0)
 8556B6545B78022FE55705A83C3E751C463F56C7 FamilyFeud_SNES              -- Family Feud SNES (US 1.1)
+54D8DA70C5FE2BA8223FECB58803C873EA1A5AA6 FatalFury1_ARC               -- Fatal Fury - King of Fighters / Garou Densetsu - Shukumei no Tatakai (NGM-033 ~ NGH-033)
 09D97003BF9D676F24A75CF3E1DCED28CDA3BE59 IceClimber_NES               -- Ice Climber (North America, Europe)
 1690E419BC2435739EFBE59A64D83538FF7E16B4 IceClimber_NES               -- Ice Climber (Japan)
 86C392A1D9A731FA48E148AFBE60AF75F918CB5A Jackal_NES                   -- Jackal NES
@@ -314,6 +315,7 @@ BA9742A4                                 PaRappa1_PS1                 -- PaRappa
 CE0FDE21D2C418B24C3D904E57DF466E         ROCKET_KNIGHT_ADVENTURES_GEN -- Rocket Knight Adventures, Genesis
 E2DB0B04B75F19226C9D524D422143318141710A Rollergames_NES              -- Rollergames, NES (US)
 C3BD515E47137F32367F923F40139EA3F959FB93 Rollergames_NES              -- Rollergames, NES (Europe)
+998DCDF117EA63BA64FF37335A0719A4         FatmanSlaughterSport_GEN     -- Slaughter Sport (U) [c][!]
 3A95FA7BAB8AA16E43A5652158ABEC2B74B277B4 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (North America)
 8E37429077AEDE24A635AF20AD9B7E43B52D1FB9 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (Europe)
 ACF534C0162FC06EAF9EFCE0C5AEF2E924504720 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (North America, Isometric D-Pad Adjustment Hack/Improvement)


### PR DESCRIPTION
Adds single player support for the original arcade version of Fatal Fury as well as the Mega Drive / Genesis version of Slaughter Sport.

Note that only single player shuffler support has been added for Fatal Fury; the game does feature two player co-op if a second player joins during a single player game, but this then turns into a versus match, and then ultimately returns to a single player game with the remaining player. Slaughter Sport does not have a co-op feature of any sort.

Fatal Fury uses a standard fighting game multiple round system. Slaughter Sport only has single round fights. It should also be noted that Slaughter Sport features a hidden continue system; the player is normally unable to continue after their third loss because they've been eaten by a landshark.

Neither Fatal Fury nor Slaughter Sport have true combo systems, but Fatal Fury has multi-hit attacks. Both will likely benefit from updates to grace to enforce a minimum time without damage before shuffling; the current grace values used are based on the assumption of that update.


Both games have been tested primarily in the early game.