### PR TITLE
Add basic BCD conversion functions

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -454,6 +454,38 @@ local function value_in_range(value, min, max, fallback)
 	end
 end
 
+-- converts an unsigned value from BCD format, e.g. 0x1234 -> 1234
+local function from_bcd(value)
+
+	local acc, mul = 0, 1
+	
+	while value > 0 do
+		local digit = value & 0xF
+		acc = acc + digit * mul
+		
+		value = value >> 4
+		mul = mul * 10
+	end
+	
+	return acc
+end
+
+-- converts an unsigned value to BCD format, e.g. 1234 -> 0x1234
+local function to_bcd(value)
+
+	local acc, mul = 0, 1
+	
+	while value > 0 do
+		local digit = value % 10
+		acc = acc + digit * mul
+		
+		value = value // 10
+		mul = mul << 4
+	end
+	
+	return acc
+end
+
 -- Follow a 32-bit pointer chain, given a start address and a series of offsets.
 -- Returns the final address in the chain, or nil if any addresses in the chain are invalid.
 -- If restricted is true, only the typical address space 0x8000_0000-0x801F_FFFF is considered valid.


### PR DESCRIPTION
See #27 for details. Starting with a basic implementation that covers the most common use cases and worrying about the others later.

Going over the existing games from before the issue was posted and trying to be thorough, these are the cases I found:

These games all use ad-hoc conversions and can move to using these functions instead.
```
SML1_GB
SML2_GB
CV3_NES
CV3_FAMI
DRACULAX_SNES
BUBSY1_SNES
ROCKET_KNIGHT_ADVENTURES_GEN
BladesofSteel_NES
ACTRAISER_SNES
BubsyFFT_JAG
```

These games look like they should use these functions, but currently have no conversion (and so likely have issues with Infinite* Lives disabled or using a different target value). It's also possible that they are using an incorrect lives target though, so this needs checking.
```
CV4_SNES
BLOODLINES_GEN
RONDO_TG16
Rollergames_NES
Castlevania2_GB
TMNT4_SNES
PowerBlade2_NES
```

Where applicable, these should all also have the `maxlives` property specified in hexadecimal notation for clarity.

The Metroid titles here could also use these functions, as health is stored in this format. This does not have the issues lives do at present, however it may be a good idea in order to make them more future-proof.
```
MetroidNes
Metroid2
MetroidZero (for the NES mode)
```

In addition, games submitted since #27 will need to update themselves to use these functions where applicable.