### PR TITLE
Add The 3-D Battles of Worldrunner to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -7313,7 +7313,14 @@ local gamedata = {
 		p1getlc=function() return memory.read_u8(0x00E0, "RAM") end,
 		maxhp=function() return 1 end,
 		minhp=-1,
-		swap_exceptions=function() return memory.read_u8(0x07FE, "RAM")==0 end, -- player character jumping onto stage sequence; catches false positive during stage intro
+		swap_exceptions=function()
+			-- power potion is lost on the frame when boss fight begins, potentially causing shuffles, so suppress shuffling for that frame
+			local is_fighting_boss_changed, is_fighting_boss_curr, is_fighting_boss_prev = update_prev('is_fighting_boss', memory.read_u8(0x0068, "RAM"))
+			if is_fighting_boss_changed and is_fighting_boss_curr == 1 and is_fighting_boss_prev == 0 then return true end
+		
+			-- player character jumping onto stage sequence; catches false positive during stage intro
+			if memory.read_u8(0x07FE, "RAM")==0 then return true end
+			return false end,
 		CanHaveInfiniteLives=true,
 		p1livesaddr=function() return 0x00E0 end,
 		LivesWhichRAM=function() return "RAM" end,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -268,6 +268,7 @@ plugin.description =
 	-Teenage Mutant Ninja Turtles II: The Arcade Game (NES), 1-2p
 	-Teenage Mutant Ninja Turtles III: The Manhattan Project (NES), 1-2p
 	-Teenage Mutant Ninja Turtles IV: Turtles in Time (SNES), 1-2p
+	-The 3-D Battles of Worldrunner(NES), 1p
 	-The Magical Quest Starring Mickey Mouse (SNES), 1-2p
 	-The Magical Quest 2: The Great Circus Mystery Starring Mickey & Minnie (SNES), 1-2p
 	-The Magical Quest 3: Mickey to Donald - Magical Adventure 3 (SNES), 1-2p
@@ -7305,6 +7306,19 @@ local gamedata = {
 			end
 			return false
 		end,
+	},
+	['3DWorldRunner_NES']={ -- 3-D Battles of Worldrunner, The
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x00E3, "RAM") end, -- power potion: 1 when the player has extra health, 0 when they don't
+		p1getlc=function() return memory.read_u8(0x00E0, "RAM") end,
+		maxhp=function() return 1 end,
+		minhp=-1,
+		swap_exceptions=function() return memory.read_u8(0x07FE, "RAM")==0 end, -- player character jumping onto stage sequence; catches false positive during stage intro
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x00E0 end,
+		LivesWhichRAM=function() return "RAM" end,
+		maxlives=function() return 69 end,
+		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['MagicalQuestMickey1_SNES']={ -- The Magical Quest Starring Mickey Mouse (SNES)
 		func=health_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -268,7 +268,8 @@ plugin.description =
 	-Teenage Mutant Ninja Turtles II: The Arcade Game (NES), 1-2p
 	-Teenage Mutant Ninja Turtles III: The Manhattan Project (NES), 1-2p
 	-Teenage Mutant Ninja Turtles IV: Turtles in Time (SNES), 1-2p
-	-The 3-D Battles of Worldrunner(NES), 1p
+	-The 3-D Battles of Worldrunner (NES), 1p
+	-JJ Tobidase Daisakusen Part 2 (NES), 1p
 	-The Magical Quest Starring Mickey Mouse (SNES), 1-2p
 	-The Magical Quest 2: The Great Circus Mystery Starring Mickey & Minnie (SNES), 1-2p
 	-The Magical Quest 3: Mickey to Donald - Magical Adventure 3 (SNES), 1-2p

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -209,6 +209,7 @@ CAF83E879EC362D01845A950E0DA7826         Sonic3D_SAT                  -- Sonic 3
 -- other supported games!
 FF66E33EFC818B516F7994F3027A72F4BC629B30 240P_NES                     -- 240p Test Suite, NES (for the stopwatch mode)
 75B6CC94A952875C936DABFBB6157F9A11C5AC49 3DWorldRunner_NES            -- 3-D Battles of Worldrunner, The
+13B9019AA9A0EA39F00B4DD4954C080A5AEF6E92 3DWorldRunner_NES            -- JJ Tobidase Daisakusen Part 2
 716244E5                                 Alundra1_PS1_JPN             -- Alundra, PSX (Japan)
 B8CB902D                                 Alundra1_PS1_1.0_USA         -- Alundra, PSX (USA), 1.0
 DEB9A9EB                                 Alundra1_PS1_1.0_USA         -- Alundra, PSX (USA), 1.0, UnWorked Designs patch

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -208,6 +208,7 @@ CAF83E879EC362D01845A950E0DA7826         Sonic3D_SAT                  -- Sonic 3
 
 -- other supported games!
 FF66E33EFC818B516F7994F3027A72F4BC629B30 240P_NES                     -- 240p Test Suite, NES (for the stopwatch mode)
+75B6CC94A952875C936DABFBB6157F9A11C5AC49 3DWorldRunner_NES            -- 3-D Battles of Worldrunner, The
 716244E5                                 Alundra1_PS1_JPN             -- Alundra, PSX (Japan)
 B8CB902D                                 Alundra1_PS1_1.0_USA         -- Alundra, PSX (USA), 1.0
 DEB9A9EB                                 Alundra1_PS1_1.0_USA         -- Alundra, PSX (USA), 1.0, UnWorked Designs patch


### PR DESCRIPTION
Adds shuffler support for The 3-D Battles of Worldrunner.

This game uses the same animation for reviving from a death as for the intro to a new stage, which actually does cost an unusable life at the start of the game. swap_exceptions has been defined to attempt to catch the stage intro without also blocking shuffles from regular life loss.