### PR TITLE
Add miscellaneous NES platformers to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -7947,7 +7947,7 @@ local gamedata = {
 		is_valid_gamestate=function() return memory.read_u8(0x002C, "RAM")==24 end,
 		get_health=function() return memory.read_s8(0x009F, "RAM") end,	
 		other_swaps=function() return false end,
-		grace=10,
+		grace=20,
 	},
 	['CrashBandicoot1_PS1_USA']={
 		-- TODO: swap on death in bonus stages

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -128,6 +128,7 @@ plugin.description =
 
 	ADDITIONAL SUPPORTED GAMES
 	-ActRaiser (SNES), 1p
+	-Adventure Island II (NES), 1p
 	-Adventures in the Magic Kingdom (NES), 1p
 	-Adventures of the Gummi Bears (bootleg) (Genesis/Mega Drive), 1p
 	-Aero the Acro-Bat (SNES), 1p
@@ -152,6 +153,7 @@ plugin.description =
 	-Captain Novolin (SNES), 1p
 	-Chip and Dale Rescue Rangers 1 (NES), 1-2p
 	-Chip and Dale Rescue Rangers 2 (NES), 1-2p
+	-Clash At Demonhead (NES), 1p
 	-Crash Bandicoot 1-3 (PSX), 1p, US version
 	-Crash Bandicoot 4 (Bootleg) (NES), 1p
 	-Darkwing Duck (NES), 1p
@@ -220,6 +222,7 @@ plugin.description =
 	-Ninja Gaiden II - The Dark Sword of Chaos (NES), 1p
 	-Ninja Gaiden III - The Ancient Ship of Doom (NES), 1p
 	-Ninjawarriors (SNES), 1p
+	-Panic Restaurant (NES), 1p
 	-PaRappa the Rapper (PSX), 1p - shuffles on dropping a rank
 	-Pebble Beach Golf Links (Sega Saturn), 1p - Tournament Mode, shuffles after stroke
 	-Pepsiman (PSX), 1p
@@ -284,6 +287,7 @@ plugin.description =
 	-Vice: Project Doom (NES), 1p
 	-Vs. Ice Climber, set IC4-4 B-1 (Arcade), 1p
 	-WarioWare, Inc.: Mega Microgame$! (GBA), 1p - bonus games including 2p are pending
+	-Werewolf: The Last Warrior (NES), 1p
 	-Wild Guns (SNES), 1p
 	-Windjammers / Flying Power Disc (Arcade), 1p
 	-Wit's (NES), 1p
@@ -5533,6 +5537,43 @@ local gamedata = {
 		end,
 		grace=60, -- Professional/Action Mode (Nintendo Super System only???? Must verify) can combo you too rapidly to recover
 	},
+	['AdventureIsland2_NES']={ -- Adventure Island II
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return 1 end, -- the energy meter drains regularly, so it is not particularly useful to treat as a standard health bar
+		p1getlc=function() return memory.read_u8(0x07D2, "RAM") end,
+		maxhp=function() return 1 end,
+		gmode=function() return memory.read_u8(0x0204, "RAM")==14 end,
+		other_swaps=function()
+				local form_changed, form_curr, _ = update_prev('form', memory.read_u8(0x007C, "RAM"))				
+				local energy_changed, energy_curr, energy_prev = update_prev('energy', memory.read_u8(0x07D3, "RAM"))
+				
+				if energy_changed and energy_curr < energy_prev - 1  -- shuffle only when energy is lowered unusually, not by the usually regular drop by 1
+					and energy_curr > 0 then return true end -- shuffling when energy is lowered to zero can be handled by life loss
+
+				--[[ shuffle when the player takes a hit and returns to base form. forms are stored in hex. 0x0 = base, 0x10 = skateboard, 0x20 = blue camptosaurus,
+				0x30 = red captosaurus, 0x40 = pteranodon, 0x50 = elasmosaurus ]]
+				if form_changed and form_curr == 0 then return true end 
+				
+				return false
+			end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x07D2 end,
+		LivesWhichRAM=function() return "RAM" end,
+		maxlives=function() return 9 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['PanicRestaurant_NES']={ -- Panic Restaurant
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x00D7, "RAM") end,
+		p1getlc=function() return memory.read_u8(0x00D6, "RAM") end,
+		maxhp=function() return 4 end,
+		gmode=function() return memory.read_u8(0x016F, "RAM")==48 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x00D6 end,
+		LivesWhichRAM=function() return "RAM" end,
+		maxlives=function() return 9 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
 	['PaRappa1_PS1']={ -- PaRappa the Rapper, PSX
 		func=singleplayer_withlives_swap,
 		gmode=function() return memory.read_u8(0x1C3670, "MainRAM") > 0 end, -- if no points yet, no shuffle, should help avoid shuffles between rounds and give leeway at the top of a round
@@ -7221,6 +7262,17 @@ local gamedata = {
 		grace=80,
 		delay=7,
 	},
+	['WerewolfLastWarrior_NES']={ -- Werewolf: The Last Warrior
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x00BC, "RAM") end,
+		p1getlc=function() return memory.read_u8(0x0406, "RAM") end,
+		maxhp=function() return 20 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x0406 end,
+		LivesWhichRAM=function() return "RAM" end,
+		maxlives=function() return 69 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
 	['WildGuns_SNES']={ -- Wild Guns, SNES
 		func=singleplayer_withlives_swap,
 		-- only swap during gameplay, not for demo/options
@@ -7890,7 +7942,13 @@ local gamedata = {
 		ActiveP1=function() return true end, -- p1 is always active!
 		delay=5, -- good to give a slightly higher delay to make the damage more readable to the player
 	},
-
+	['ClashAtDemonhead_NES']={ -- Clash At Demonhead
+		func=health_swap,
+		is_valid_gamestate=function() return memory.read_u8(0x002C, "RAM")==24 end,
+		get_health=function() return memory.read_s8(0x009F, "RAM") end,	
+		other_swaps=function() return false end,
+		grace=10,
+	},
 	['CrashBandicoot1_PS1_USA']={
 		-- TODO: swap on death in bonus stages
 		func=function(gamemeta)

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -217,6 +217,7 @@ F031FC983A2EED4D69E223B256ECE5F037FB5D5D ACTRAISER_SNES               -- ActRais
 E8365852CC20178D42C93CD188A7AE9AF45369D7 ACTRAISER_SNES               -- ActRaiser (NTSC-U), SNES
 4CEE09160219290721E88C5DE2C7F652BAD1BB23 ACTRAISER_SNES               -- ActRaiser (USA) (Arcade), SNES
 B76621E0B9D882C8B8463203F5423CA7D45CC5BF ACTRAISER_SNES               -- ActRaiser (PAL), SNES, English
+F53FD2B03CFC5CF28D68021B47815E8710C3B44D AdventureIsland2_NES         -- Adventure Island II
 3634826A2A03074928052F90928DA10DC715E77B Anticipation                 -- Anticipation NES (US)
 A3B8D2584D24EF58569D27076AAC451D487BC320 Anticipation                 -- Anticipation NES (US) (No Intro Headered)
 3954E690CBF5241181DC592F01E87BEFA5531374 Anticipation                 -- Anticipation NES (US) (No Intro Headerless)
@@ -243,6 +244,7 @@ A60BA28ACA558FE3527D46B0DF33BDD038D4C635 CNDRR2_NES                   -- Chip an
 2E140EDBBD6BE832462B9833A1A593D5C901BF5F CNDRR2_NES                   -- Chip and Dale Rescue Rangers 2 NES (Europe)
 0B39CD3B2EBCC8430A4B2585DFD7880BC8AE63DF CNDRR2_NES                   -- Chip and Dale Rescue Rangers 2 NES (Japan)
 C45AEEC492D02E1058293F5B523E3C6323D3D2F3 CNDRR2_NES                   -- Chip and Dale Rescue Rangers 2 NES (beta)
+CD484AB73278D8D58E8068CCDCEAC6EEFBA12F68 ClashAtDemonhead_NES         -- Clash At Demonhead
 C9EA66BB7CB30AD5343F1721B1D4D3219859319B Contra_NES                   -- Contra NES (US)
 376836361F404C815D404E1D5903D5D11F4EFF0E Contra_NES                   -- Contra NES (Japan)
 265886E3F665ADF2507E7B2F08B6B2ED9D0018B2 ContraIII_SNES               -- Contra III: The Alien Wars, SNES (US)
@@ -306,6 +308,7 @@ B1796660E4A4CEFC72181D4BF4F97999BC048A77 NinjaGaiden2_NES             -- Ninja G
 3F2E6DAC76BA14EFC177B5653AB043E53A04D365 NinjaGaiden3_NES             -- Ninja Gaiden III NES (US)
 6958358C4A554BDC6D4F8571F83829989D0BB018 NinjaGaiden3_NES             -- Ninja Gaiden III NES (Restored & Restored+ hack)
 2FF9443C                                 NBA_JAM_PS1                  -- NBA Jam Tournament Edition, PS1 (North America)
+E6AD766B7F42113325DEB96917CCD81DA92EEFA7 PanicRestaurant_NES          -- Panic Restaurant
 BA9742A4                                 PaRappa1_PS1                 -- PaRappa the Rapper, PS1 (US)
 24AD606614D7D2A510F5FD58FCDC28FE         PEBBLE_BEACH_GOLF_LINKS_SAT  -- Pebble Beach Golf Links, Saturn (North America)
 6531FF3A062C2A83FA9683BF8A859A3500E8D9AF Contra_NES                   -- Probotector (NES) (Europe)
@@ -329,6 +332,8 @@ A2DD48574B9F7A49977C91D12D5C52C17C2C82AA UNSquadron_SNES              -- U.N. Sq
 0F500AB60B7DDB382F70A9EA3FB68E7FC593091C UNSquadron_SNES              -- U.N. Squadron (-grind hack)
 B9E2FCAABC7BB71BEC3B6AD4BA1CD26E2A441A9C UNSquadron_SNES              -- U.N. Squadron (Europe)
 3F556448D290FA5406D6ED367FEE16CC02387AD3 WarioWare_GBA                -- WarioWare, Inc.: Mega Microgame$! (US)
+8580B3DEEDDFA75C12DFE2F6CAB8D062E52FDB34 WerewolfLastWarrior_NES      -- Werewolf: The Last Warrior
+
 
 -- NEW BATCHES FOR 2025
 CC8CB9EEBAAE9C695BE7EE965E3C8D7CF82C6D18 AdvMagicKingdom_NES          -- Adventures in the Magic Kingdom (US)


### PR DESCRIPTION
Adds support for Panic Restaurant, Werewolf: The Last Warrior, Adventure Island II for the NES, and Clash at Demonhead.

Adventure Island does not feature a standard health system, but has a food gauge which empties by 1 regularly until the player hits 0 and loses a life. Some events like bumping into stones do not instantly kill the player, but cost them their powerup if they have one as if they had taken a fatal hit, as well as draining their food meter. Since this resembles damage, other_swaps has been defined to include a shuffle if the food gauge lowers by more than the regular value of 1.

All games have been tested primarily in the early game.