### PR TITLE
Add Pac-Man series to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -221,6 +221,7 @@ plugin.description =
 	-Ninja Gaiden III - The Ancient Ship of Doom (NES), 1p
 	-Ninjawarriors (SNES), 1p
 	-Pac-Land (World) (Arcade), 1p
+	-Pac-Land (U) (TG-16), 1p
 	-Pac-Man Championship Edition, (NES), 1p
 	-PaRappa the Rapper (PSX), 1p - shuffles on dropping a rank
 	-Pebble Beach Golf Links (Sega Saturn), 1p - Tournament Mode, shuffles after stroke
@@ -5544,6 +5545,17 @@ local gamedata = {
 		p1livesaddr=function() return 0x0100 end,
 		LivesWhichRAM=function() return "mc6809e : ram : 0x2000-0x37FF" end,
 		maxlives=function() return 9 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['PacLand_TG16']={ -- Pac-Land (U) (TurboGrafx-16)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return 1 end,
+		p1getlc=function() return memory.read_u8(0x0167, "Main Memory") end,
+		maxhp=function() return 1 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x0167 end,
+		LivesWhichRAM=function() return "Main Memory" end,
+		maxlives=function() return 70 end,
 		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['PacManChampionship_NES']={ -- Pac-Man Championship Edition, NES

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -220,9 +220,9 @@ plugin.description =
 	-Ninja Gaiden II - The Dark Sword of Chaos (NES), 1p
 	-Ninja Gaiden III - The Ancient Ship of Doom (NES), 1p
 	-Ninjawarriors (SNES), 1p
-	-Pac-Land (World) (Arcade), 1p
-	-Pac-Land (U) (TG-16), 1p
-	-Pac-Man Championship Edition, (NES), 1p
+	-Pac-Land (Arcade), 1p
+	-Pac-Land (TG-16), 1p
+	-Pac-Man Championship Edition (NES), 1p
 	-PaRappa the Rapper (PSX), 1p - shuffles on dropping a rank
 	-Pebble Beach Golf Links (Sega Saturn), 1p - Tournament Mode, shuffles after stroke
 	-Pepsiman (PSX), 1p

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -220,6 +220,8 @@ plugin.description =
 	-Ninja Gaiden II - The Dark Sword of Chaos (NES), 1p
 	-Ninja Gaiden III - The Ancient Ship of Doom (NES), 1p
 	-Ninjawarriors (SNES), 1p
+	-Pac-Land (World) (Arcade), 1p
+	-Pac-Man Championship Edition, (NES), 1p
 	-PaRappa the Rapper (PSX), 1p - shuffles on dropping a rank
 	-Pebble Beach Golf Links (Sega Saturn), 1p - Tournament Mode, shuffles after stroke
 	-Pepsiman (PSX), 1p
@@ -5532,6 +5534,35 @@ local gamedata = {
 			return gameMode >= 1 and gameMode <= 8 -- p1 is always active, but don't set lives when in sim mode
 		end,
 		grace=60, -- Professional/Action Mode (Nintendo Super System only???? Must verify) can combo you too rapidly to recover
+	},
+	['PacLand_ARC']={ -- Pac-Land (World)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return 1 end,
+		p1getlc=function() return memory.read_u8(0x0100, "mc6809e : ram : 0x2000-0x37FF") end,
+		maxhp=function() return 1 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x0100 end,
+		LivesWhichRAM=function() return "mc6809e : ram : 0x2000-0x37FF" end,
+		maxlives=function() return 9 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['PacManChampionship_NES']={ -- Pac-Man Championship Edition, NES
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return 1 end,
+		p1getlc=function() return (10 * memory.read_u8(0x0451, "RAM")) + memory.read_u8(0x0450, "RAM") end, -- both digits for lives are stored separately
+		maxhp=function() return 1 end,
+		gmode=function() return memory.read_u8(0x043F, "RAM")==1 end,
+		other_swaps=function()
+			-- player's lives do not drop again when hit while at 0 lives, so damage on last life needs to be accounted for
+			local death_animation_changed, death_animation_cur, death_animation_prev = update_prev('death_animation', memory.read_u8(0x0057, "RAM"))
+			return death_animation_changed
+				and death_animation_cur == 7
+				and ((10 * memory.read_u8(0x0451, "RAM")) + memory.read_u8(0x0450, "RAM")) == 0 end,
+		CanHaveInfiniteLives=false, -- since the win condition is just surviving the timer, player no longer needs to actually do anything to succeed if they can't die
+		p1livesaddr=function() return 0x0450 end, -- address is for only unit digit; tens digit is stored at 0x0451
+		LivesWhichRAM=function() return "RAM" end,
+		maxlives=function() return 9 end, -- since only one digit is used, max is 9. max with both digits would be 99
+		ActiveP1=function() return true end, -- p1 is always active!		
 	},
 	['PaRappa1_PS1']={ -- PaRappa the Rapper, PSX
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -307,6 +307,7 @@ B1796660E4A4CEFC72181D4BF4F97999BC048A77 NinjaGaiden2_NES             -- Ninja G
 6958358C4A554BDC6D4F8571F83829989D0BB018 NinjaGaiden3_NES             -- Ninja Gaiden III NES (Restored & Restored+ hack)
 2FF9443C                                 NBA_JAM_PS1                  -- NBA Jam Tournament Edition, PS1 (North America)
 2F68234C602507E45F958D2CFF17BDE58E720DA1 PacLand_ARC                  -- Pac-Land (World)
+5CC45BFE5DA979C51417E77BFE221A2B         PacLand_TG16                 -- Pac-Land (U)
 90AB4682C1CFBE78D9E32BAFF37600B0114F6E74 PacManChampionship_NES       -- Pac-Man Championship Edition, NES
 BA9742A4                                 PaRappa1_PS1                 -- PaRappa the Rapper, PS1 (US)
 24AD606614D7D2A510F5FD58FCDC28FE         PEBBLE_BEACH_GOLF_LINKS_SAT  -- Pebble Beach Golf Links, Saturn (North America)

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -306,6 +306,8 @@ B1796660E4A4CEFC72181D4BF4F97999BC048A77 NinjaGaiden2_NES             -- Ninja G
 3F2E6DAC76BA14EFC177B5653AB043E53A04D365 NinjaGaiden3_NES             -- Ninja Gaiden III NES (US)
 6958358C4A554BDC6D4F8571F83829989D0BB018 NinjaGaiden3_NES             -- Ninja Gaiden III NES (Restored & Restored+ hack)
 2FF9443C                                 NBA_JAM_PS1                  -- NBA Jam Tournament Edition, PS1 (North America)
+2F68234C602507E45F958D2CFF17BDE58E720DA1 PacLand_ARC                  -- Pac-Land (World)
+90AB4682C1CFBE78D9E32BAFF37600B0114F6E74 PacManChampionship_NES       -- Pac-Man Championship Edition, NES
 BA9742A4                                 PaRappa1_PS1                 -- PaRappa the Rapper, PS1 (US)
 24AD606614D7D2A510F5FD58FCDC28FE         PEBBLE_BEACH_GOLF_LINKS_SAT  -- Pebble Beach Golf Links, Saturn (North America)
 6531FF3A062C2A83FA9683BF8A859A3500E8D9AF Contra_NES                   -- Probotector (NES) (Europe)


### PR DESCRIPTION
Adds support for Pac-Land for the arcade, as well as Pac-Man: Championship Edition for the NES.

Pac-Man: Championship Edition may require a gamedb entry to run properly.

Pac-Land is a traditional platformer. Pac-Man: Championship Edition is a dot eating game, albeit a more pathed survival game than the original games.

The stages in Pac-Man: Championship Edition are not cleared by eating all of the pellets onscreen; instead, the goal is to survive until the timer expires. CanHaveInfiniteLives has been set to false so that progress can still be lost.

Both games have been tested primarily in the early game.