### PR TITLE
Add Shinobi series to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -243,11 +243,11 @@ plugin.description =
 	-SD Gundam Sangokushi Rainbow Tairiku Senki (Japan) (Arcade), 1p
 	-Shaq-Fu (Genesis/Mega Drive), 1p
 	-Shatterhand (NES), 1p
-	-Shinobi (set 6, System 16A) (unprotected) (Arcade), 1p
-	-Revenge of Shinobi, The (W) (REV01) [!] (Genesis/Mega Drive), 1p
+	-Shinobi (Arcade), 1p
+	-Revenge of Shinobi, The (Genesis/Mega Drive), 1p
 	-Shinobi III (Genesis/Mega Drive), 1p
-	-Shinobi Legions (U) (Saturn), 1p
-	-Shinobi-X - Shin Shinobi Den (Europe) (Saturn), 1p
+	-Shinobi Legions (Saturn), 1p
+	-Shinobi-X - Shin Shinobi Den (Saturn), 1p
 	-Simpsons: Bart vs. the World (NES), 1p
 	-Snake Rattle 'n Roll (NES), 1p
 	-Sonic Jam 6 (bootleg) (Genesis/Mega Drive), 1p

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -243,6 +243,8 @@ plugin.description =
 	-SD Gundam Sangokushi Rainbow Tairiku Senki (Japan) (Arcade), 1p
 	-Shaq-Fu (Genesis/Mega Drive), 1p
 	-Shatterhand (NES), 1p
+	-Shinobi (set 6, System 16A) (unprotected) (Arcade), 1p
+	-Revenge of Shinobi, The (W) (REV01) [!] (Genesis/Mega Drive), 1p
 	-Shinobi III (Genesis/Mega Drive), 1p
 	-Simpsons: Bart vs. the World (NES), 1p
 	-Snake Rattle 'n Roll (NES), 1p
@@ -6186,6 +6188,28 @@ local gamedata = {
 		LivesWhichRAM=function() return "WRAM" end,
 		p1livesaddr=function() return 0x00b6 end,
 		maxlives=function() return 9 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['Shinobi_ARC']={ -- Shinobi (set 6, System 16A) (unprotected) (Arcade)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return 1 end,
+		p1getlc=function() return memory.read_u8(0x1750, "m68000 : ram : 0xC70000-0xC73FFF") end,
+		maxhp=function() return 1 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x1750 end,
+		LivesWhichRAM=function() return "m68000 : ram : 0xC70000-0xC73FFF" end,
+		maxlives=function() return 6 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['ShinobiRevenge_GEN']={ -- Revenge of Shinobi, The (W) (REV01) [!]
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x00E13B, "68K RAM") end,
+		p1getlc=function() return memory.read_u8(0x00E141, "68K RAM") end,
+		maxhp=function() return 8 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x00E141 end,
+		LivesWhichRAM=function() return "68K RAM" end,
+		maxlives=function() return 10 end,
 		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['ShinobiIII_GEN']={ -- Shinobi III, Genesis

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -247,6 +247,7 @@ plugin.description =
 	-Revenge of Shinobi, The (W) (REV01) [!] (Genesis/Mega Drive), 1p
 	-Shinobi III (Genesis/Mega Drive), 1p
 	-Shinobi Legions (U) (Saturn), 1p
+	-Shinobi-X - Shin Shinobi Den (Europe) (Saturn), 1p
 	-Simpsons: Bart vs. the World (NES), 1p
 	-Snake Rattle 'n Roll (NES), 1p
 	-Sonic Jam 6 (bootleg) (Genesis/Mega Drive), 1p
@@ -6231,6 +6232,17 @@ local gamedata = {
 		maxhp=function() return 6 end,
 		CanHaveInfiniteLives=true,
 		p1livesaddr=function() return 0x0252B9 end,
+		LivesWhichRAM=function() return "Work Ram High" end,
+		maxlives=function() return 69 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['ShinobiX_SAT']={ -- Shinobi Legions (U)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x0EA41B, "Work Ram High") end,
+		p1getlc=function() return memory.read_u8(0x0252DD, "Work Ram High") end,
+		maxhp=function() return 6 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x0252DD end,
 		LivesWhichRAM=function() return "Work Ram High" end,
 		maxlives=function() return 69 end,
 		ActiveP1=function() return true end, -- p1 is always active!

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -246,6 +246,7 @@ plugin.description =
 	-Shinobi (set 6, System 16A) (unprotected) (Arcade), 1p
 	-Revenge of Shinobi, The (W) (REV01) [!] (Genesis/Mega Drive), 1p
 	-Shinobi III (Genesis/Mega Drive), 1p
+	-Shinobi Legions (U) (Saturn), 1p
 	-Simpsons: Bart vs. the World (NES), 1p
 	-Snake Rattle 'n Roll (NES), 1p
 	-Sonic Jam 6 (bootleg) (Genesis/Mega Drive), 1p
@@ -6220,6 +6221,17 @@ local gamedata = {
 		CanHaveInfiniteLives=true,
 		LivesWhichRAM=function() return "68K RAM" end,
 		p1livesaddr=function() return 0x37e0 end,
+		maxlives=function() return 69 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['ShinobiLegions_SAT']={ -- Shinobi Legions (U)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x0EA2CB, "Work Ram High") end,
+		p1getlc=function() return memory.read_u8(0x0252B9, "Work Ram High") end,
+		maxhp=function() return 6 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x0252B9 end,
+		LivesWhichRAM=function() return "Work Ram High" end,
 		maxlives=function() return 69 end,
 		ActiveP1=function() return true end, -- p1 is always active!
 	},

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -314,6 +314,8 @@ BA9742A4                                 PaRappa1_PS1                 -- PaRappa
 CE0FDE21D2C418B24C3D904E57DF466E         ROCKET_KNIGHT_ADVENTURES_GEN -- Rocket Knight Adventures, Genesis
 E2DB0B04B75F19226C9D524D422143318141710A Rollergames_NES              -- Rollergames, NES (US)
 C3BD515E47137F32367F923F40139EA3F959FB93 Rollergames_NES              -- Rollergames, NES (Europe)
+110F6042A70B3220FD3DF0F8238BA8C9B254B46B Shinobi_ARC                  -- Shinobi (set 6, System 16A) (unprotected) (Arcade)
+B7EEED1BD8420CE1D895B2CA46A0643A         ShinobiRevenge_GEN           -- Revenge of Shinobi, The (W) (REV01) [!]
 3A95FA7BAB8AA16E43A5652158ABEC2B74B277B4 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (North America)
 8E37429077AEDE24A635AF20AD9B7E43B52D1FB9 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (Europe)
 ACF534C0162FC06EAF9EFCE0C5AEF2E924504720 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (North America, Isometric D-Pad Adjustment Hack/Improvement)

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -317,6 +317,7 @@ C3BD515E47137F32367F923F40139EA3F959FB93 Rollergames_NES              -- Rollerg
 110F6042A70B3220FD3DF0F8238BA8C9B254B46B Shinobi_ARC                  -- Shinobi (set 6, System 16A) (unprotected) (Arcade)
 B7EEED1BD8420CE1D895B2CA46A0643A         ShinobiRevenge_GEN           -- Revenge of Shinobi, The (W) (REV01) [!]
 E5A11D97DCD9E71EA610FDE2B4D47630         ShinobiLegions_SAT           -- Shinobi Legions (U)
+B18168229EE27740972C6C6D878D3059         ShinobiX_SAT                 -- Shinobi-X - Shin Shinobi Den (Europe)
 3A95FA7BAB8AA16E43A5652158ABEC2B74B277B4 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (North America)
 8E37429077AEDE24A635AF20AD9B7E43B52D1FB9 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (Europe)
 ACF534C0162FC06EAF9EFCE0C5AEF2E924504720 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (North America, Isometric D-Pad Adjustment Hack/Improvement)

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -316,6 +316,7 @@ E2DB0B04B75F19226C9D524D422143318141710A Rollergames_NES              -- Rollerg
 C3BD515E47137F32367F923F40139EA3F959FB93 Rollergames_NES              -- Rollergames, NES (Europe)
 110F6042A70B3220FD3DF0F8238BA8C9B254B46B Shinobi_ARC                  -- Shinobi (set 6, System 16A) (unprotected) (Arcade)
 B7EEED1BD8420CE1D895B2CA46A0643A         ShinobiRevenge_GEN           -- Revenge of Shinobi, The (W) (REV01) [!]
+E5A11D97DCD9E71EA610FDE2B4D47630         ShinobiLegions_SAT           -- Shinobi Legions (U)
 3A95FA7BAB8AA16E43A5652158ABEC2B74B277B4 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (North America)
 8E37429077AEDE24A635AF20AD9B7E43B52D1FB9 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (Europe)
 ACF534C0162FC06EAF9EFCE0C5AEF2E924504720 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (North America, Isometric D-Pad Adjustment Hack/Improvement)


### PR DESCRIPTION
Adds support for the original Shinobi for arcade as well as The Revenge of Shinobi for Mega Drive/Genesis.

The original Shinobi does not feature health, only lives. The Revenge of Shinobi features both health and lives.

Both games have been tested primarily in the early game.