### PR TITLE
Add Skyblazer to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -245,7 +245,7 @@ plugin.description =
 	-Shatterhand (NES), 1p
 	-Shinobi III (Genesis/Mega Drive), 1p
 	-Simpsons: Bart vs. the World (NES), 1p
-	-Skyblazer (USA) (NES), 1p
+	-Skyblazer (SNES), 1p
 	-Snake Rattle 'n Roll (NES), 1p
 	-Sonic Jam 6 (bootleg) (Genesis/Mega Drive), 1p
 	-Sparkster (SNES), 1p

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -245,6 +245,7 @@ plugin.description =
 	-Shatterhand (NES), 1p
 	-Shinobi III (Genesis/Mega Drive), 1p
 	-Simpsons: Bart vs. the World (NES), 1p
+	-Skyblazer (USA) (NES), 1p
 	-Snake Rattle 'n Roll (NES), 1p
 	-Sonic Jam 6 (bootleg) (Genesis/Mega Drive), 1p
 	-Sparkster (SNES), 1p
@@ -6215,6 +6216,18 @@ local gamedata = {
 		LivesWhichRAM=function() return "RAM" end,
 		p1livesaddr=function() return 0x06c1 end,
 		maxlives=function() return 5 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['Skyblazer_SNES']={ -- Skyblazer (USA)
+		func=health_swap,
+		is_valid_gamestate=function() return memory.read_u8(0x00308D, "WRAM") == 13 -- game is running normally and is not in intro stage end cutscene
+			and memory.read_u8(0x00009F, "WRAM") ~= 0 end, -- not in stage transition; hp drops to zero for exactly one frame during screen transitions
+		get_health=function() return memory.read_u8(0x00F801, "WRAM") end,	
+		other_swaps=function() return false end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x001F00 end,
+		LivesWhichRAM=function() return "WRAM" end,
+		maxlives=function() return 69 end,
 		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['Sparkster_SNES']={ -- Sparkster, SNES

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -314,6 +314,7 @@ BA9742A4                                 PaRappa1_PS1                 -- PaRappa
 CE0FDE21D2C418B24C3D904E57DF466E         ROCKET_KNIGHT_ADVENTURES_GEN -- Rocket Knight Adventures, Genesis
 E2DB0B04B75F19226C9D524D422143318141710A Rollergames_NES              -- Rollergames, NES (US)
 C3BD515E47137F32367F923F40139EA3F959FB93 Rollergames_NES              -- Rollergames, NES (Europe)
+8426A16F7D8656C8D2CE4AC3151EC96B433F938D Skyblazer_SNES               -- Skyblazer (USA)
 3A95FA7BAB8AA16E43A5652158ABEC2B74B277B4 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (North America)
 8E37429077AEDE24A635AF20AD9B7E43B52D1FB9 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (Europe)
 ACF534C0162FC06EAF9EFCE0C5AEF2E924504720 SNAKE_RATTLE_N_ROLL_NES      -- Snake Rattle 'N' Roll, NES (North America, Isometric D-Pad Adjustment Hack/Improvement)


### PR DESCRIPTION
Added support for Skyblazer.

Skyblazer features health and lives in most levels, but not in the first stage. health_swap is used to avoid complexities due to absent lives in the first stage.

Health drops to zero for one frame during stage transitions. Additionally, a cutscene at the end of the first stage involves the player being attacked until their health runs out. is_valid_gamestate has been defined to attempt to capture both situations.

Skyblazer has primarily been tested in the early game.