### PR TITLE
Add Dragon Ball: Advanced Adventure to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -160,7 +160,7 @@ plugin.description =
 	-Do-Re-Mi Fantasy - Milon no Dokidoki Daibouken (SNES), 1p
 	-Double Dragon 1 (NES), 1-2p, Mode A or B, shuffles on knockdown and death
 	-Double Dragon 2 (NES), 1-2p, shuffles on knockdown and death
-	-Dragon Ball - Advanced Adventure (USA) (GBA), 1p
+	-Dragon Ball - Advanced Adventure (GBA), 1p
 	-DuckTales (NES), 1p
 	-DuckTales 2 (NES), 1p
 	-Dynamite Headdy (Genesis/Mega Drive), 1p

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -160,6 +160,7 @@ plugin.description =
 	-Do-Re-Mi Fantasy - Milon no Dokidoki Daibouken (SNES), 1p
 	-Double Dragon 1 (NES), 1-2p, Mode A or B, shuffles on knockdown and death
 	-Double Dragon 2 (NES), 1-2p, shuffles on knockdown and death
+	-Dragon Ball - Advanced Adventure (USA) (GBA), 1p
 	-DuckTales (NES), 1p
 	-DuckTales 2 (NES), 1p
 	-Dynamite Headdy (Genesis/Mega Drive), 1p
@@ -4913,6 +4914,59 @@ local gamedata = {
 		ActiveP2=function() return memory.read_u8(0x0433, "RAM") > 0 end,
 		delay=7,
 		-- let players see the knockdown happen
+	},
+	['DragonballAdvanced_GBA']={ -- Dragon Ball - Advanced Adventure (USA)
+		func=function() return function()		
+			-- separate addresses are used for health in the unarmed fighting game mode and the other, primarily platforming game stages
+			local platformhealth_changed, platformhealth_curr, platformhealth_prev = update_prev('platformhealth', memory.read_u16_le(0x020646, "EWRAM"))
+			local fighthealth_changed, fighthealth_curr, fighthealth_prev = update_prev('fighthealth', memory.read_s16_le(0x029986, "EWRAM"))
+		
+			local maxplatformhp = 1024
+			local maxfighthp = 512
+			local minhp = 0 -- seems to not apply in fighting mode
+			local maxstun = 16
+			local minstun = 0
+		
+			local stunmeter_changed, stunmeter_curr, stunmeter_prev = update_prev('stunmeter', memory.read_u8(0x029988, "EWRAM"))
+		
+			local gmode = memory.read_u8(0x2EF1, "IWRAM")==66
+			
+			local hptypeused = memory.read_u8(0x000520, "EWRAM")
+			
+			local platformhptype=204
+			local fighthptype=216
+			
+			if gmode then -- check for gmode
+				if hptypeused == platformhptype and platformhealth_curr >= minhp and platformhealth_curr <= maxplatformhp then
+					if platformhealth_changed and platformhealth_curr < platformhealth_prev then return true end
+				elseif hptypeused == fighthptype and fighthealth_curr <= maxplatformhp then
+					--[[ The fighting mode uses a different health system. In this mode, both fighters do not take damage from normal hits until their stun meter is broken, at 
+					which point they will take damage from every hit until the combo ends and their health is recovered.
+					
+					Since all damage takes place when the stun is at zero, a natural restriction on shuffling is to allow one shuffle for each meter break. Since it's possible
+					for the meter to be broken without taking damage, we should also not shuffle on meter breaks that did not result in damage. So, we'll check if damage is 
+					caused, then shuflfe when the stun is restored. ]]
+			
+					if prevdata["wasdamagetaken"] == nil then 
+						prevdata["wasdamagetaken"] = false -- set a starting value of false, but do not overwrite a true value
+					elseif stunmeter_curr == minstun and fighthealth_changed and fighthealth_curr < fighthealth_prev then
+						prevdata["wasdamagetaken"] = true end
+
+					-- stun meter instant restores to full when combo is dropped
+					if prevdata["wasdamagetaken"] and stunmeter_changed and stunmeter_curr == maxstun and stunmeter_prev == minstun then return true end
+
+					-- stun meter is not restored after ko, so we need to specifically shuffle on ko
+					if fighthealth_changed and fighthealth_curr <= 0 then return true end
+				end
+			end
+		
+			return false end
+		end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x029F36 end,
+		LivesWhichRAM=function() return "EWRAM" end,
+		maxlives=function() return 69 end,
+		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['DKC1_SNES']={ -- Donkey Kong Country (SNES)
 		func=iframe_health_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -4931,10 +4931,10 @@ local gamedata = {
 		
 			local gmode = memory.read_u8(0x2EF1, "IWRAM")==66
 			
-			local hptypeused = memory.read_u8(0x000520, "EWRAM")
+			local hptypeused = memory.read_u8(0x029937, "EWRAM")
 			
-			local platformhptype=204
-			local fighthptype=216
+			local platformhptype=0
+			local fighthptype=3
 			
 			if gmode then -- check for gmode
 				if hptypeused == platformhptype and platformhealth_curr >= minhp and platformhealth_curr <= maxplatformhp then

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -357,6 +357,7 @@ E56EBBCD0A2DB7BF58E2209ADB96F589F0100702 DoReMiFantasy_SNES           -- Do-Re-M
 345E32FDA9EE9DA42B96B50E9F3E89A506C5F03F DoReMiFantasy_SNES           -- Do-Re-Mi Fantasy - Milon no Dokidoki Daibouken (Gaijin translation)
 4E6D8F085CA197479D59912C1D58E4F3B40C28AC DonkeyKongLand_GB            -- Donkey Kong Land (USA, Europe)
 69C267201EB327D086164A15B8A57C4A43E107D8 DonkeyKongLand_GB            -- Donkey Kong Land (new colors mode v1.01)
+1338584D8CFA57402603197E65D2E2FF0184D24F DragonballAdvanced_GBA       -- Dragon Ball - Advanced Adventure (USA)
 4B5720BC6E0590C9372CFBD0C418F8EFD4D0C96D DuckTales_NES                -- Duck Tales (US)
 2E4716E9FACCAF362FBE7D7FD05246332BB2BBBC DuckTales_NES                -- Duck Tales (modded moon music)
 76093EA07A16FDAA8AA58730FD29B4977A264B5E DuckTales2_NES               -- Duck Tales 2 (US)


### PR DESCRIPTION
Adds Dragonball Advanced Adventure for Gameboy Advance.

Advanced Adventure features two health systems, roughly divided between segments where Goku is equipped with his Power Pole and totally unarmed martial arts matches. Shuffler support has been implemented with an anonymous function to more clearly describe the functionality of the two systems.

While health is used in all modes, lives are only used in story mode as well as in extra mode, which is an expanded version of story mode that allows the player to use any character in the game. For convenience, shuffling is based entirely on damage, with shuffles occurring when health hits zero rather than on loss of lives.

In the unarmed fighting matches, the player and opponent must typically be stunned before taking damage; damage will be not be taken until the stun meter is emptied, at which point damage will be dealt by attacks until the end of the combo. Since the player will not regain control until their stun meter recovers, shuffling has been set to occur when the stun meter recovers after the player has taken damage. prevdata is used to store the flag for if the player has been damaged between frames based on the functionality of update_prev.

Potential issue: beam attacks can break the stun meter and cause damage simultaneously, so there might be unexpected behaviour around those attacks.