### PR TITLE
Add miscellaneous ninja platformers to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -219,6 +219,8 @@ plugin.description =
 	-Ninja Gaiden (NES), 1p
 	-Ninja Gaiden II - The Dark Sword of Chaos (NES), 1p
 	-Ninja Gaiden III - The Ancient Ship of Doom (NES), 1p
+	-Ninja Gaiden Shadow (USA), 1p
+	-Ninja Spirit (U) (TurboGrafx-16), 1p
 	-Ninjawarriors (SNES), 1p
 	-PaRappa the Rapper (PSX), 1p - shuffles on dropping a rank
 	-Pebble Beach Golf Links (Sega Saturn), 1p - Tournament Mode, shuffles after stroke
@@ -5599,6 +5601,28 @@ local gamedata = {
 		ActiveP1=function() return true end, -- p1 is always active!
 		grace=100, -- approx 60 frames from knockback/iframes until vulnerable again
 	},
+	['NinjaGaidenShadow_GB']={ -- Ninja Gaiden Shadow (USA)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x009B, "WRAM") end, 
+		p1getlc=function() return memory.read_u8(0x009C, "WRAM") end,
+		maxhp=function() return 6 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x009C end,
+		LivesWhichRAM=function() return "WRAM" end,
+		maxlives=function() return 9 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},
+	['NinjaSpirit_TG16']={ -- Ninja Spirit (U)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x17C9, "Main Memory") end,
+		p1getlc=function() return memory.read_u8(0x0B68, "Main Memory") end, 
+		maxhp=function() return 5 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x0B68 end,
+		LivesWhichRAM=function() return "Main Memory" end,
+		maxlives=function() return 9 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+	},	
 	['BuckyOHare_NES']={ -- Bucky O'Hare, NES
 		func=singleplayer_withlives_swap,
 		p1gethp=function() return memory.read_u8(0x5a0, "RAM") end,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -219,8 +219,8 @@ plugin.description =
 	-Ninja Gaiden (NES), 1p
 	-Ninja Gaiden II - The Dark Sword of Chaos (NES), 1p
 	-Ninja Gaiden III - The Ancient Ship of Doom (NES), 1p
-	-Ninja Gaiden Shadow (USA), 1p
-	-Ninja Spirit (U) (TurboGrafx-16), 1p
+	-Ninja Gaiden Shadow (GB), 1p
+	-Ninja Spirit (TG-16), 1p
 	-Ninjawarriors (SNES), 1p
 	-PaRappa the Rapper (PSX), 1p - shuffles on dropping a rank
 	-Pebble Beach Golf Links (Sega Saturn), 1p - Tournament Mode, shuffles after stroke

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -5617,6 +5617,7 @@ local gamedata = {
 		p1gethp=function() return memory.read_u8(0x17C9, "Main Memory") end,
 		p1getlc=function() return memory.read_u8(0x0B68, "Main Memory") end, 
 		maxhp=function() return 5 end,
+		gmode=function() return memory.read_u8(0x0B6B, "Main Memory")==1 end,
 		CanHaveInfiniteLives=true,
 		p1livesaddr=function() return 0x0B68 end,
 		LivesWhichRAM=function() return "Main Memory" end,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -305,6 +305,8 @@ CA513F841D75EFEB33BB8099FB02BEEB39F6BB9C NinjaGaiden1_NES             -- Ninja G
 B1796660E4A4CEFC72181D4BF4F97999BC048A77 NinjaGaiden2_NES             -- Ninja Gaiden II NES (US)
 3F2E6DAC76BA14EFC177B5653AB043E53A04D365 NinjaGaiden3_NES             -- Ninja Gaiden III NES (US)
 6958358C4A554BDC6D4F8571F83829989D0BB018 NinjaGaiden3_NES             -- Ninja Gaiden III NES (Restored & Restored+ hack)
+8AADD7DFB4ADD75D5AC5351658762E5F56E78C66 NinjaGaidenShadow_GB         -- Ninja Gaiden Shadow (USA)
+ADECF9E9D9BE8A300818AD2CC09D49FE         NinjaSpirit_TG16             -- Ninja Spirit (U) (TurboGrafx-16)
 2FF9443C                                 NBA_JAM_PS1                  -- NBA Jam Tournament Edition, PS1 (North America)
 BA9742A4                                 PaRappa1_PS1                 -- PaRappa the Rapper, PS1 (US)
 24AD606614D7D2A510F5FD58FCDC28FE         PEBBLE_BEACH_GOLF_LINKS_SAT  -- Pebble Beach Golf Links, Saturn (North America)


### PR DESCRIPTION
Adds support for Ninja Spirit for the TurboGrafx-16 and Ninja Gaiden Shadow for the Gameboy.

Ninja Spirit features two difficulty modes. Arcade mode, as per the actual arcade version of the game, only features lives; all damage acts an instant kill. In PC Engine mode, the player also has health, and so is capable of absorbing more damage. The current implementation should work for both difficulty modes.

Ninja Gaiden Shadow uses standard health and lives mechanics.