### PR TITLE
Add Transformers: Convoy no Nazo to shuffler

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -263,6 +263,7 @@ plugin.description =
 	-Super Smash TV (SNES), 1p
 	-TaleSpin (NES), 1p
 	-Tarzan: Lord of the Jungle (unreleased) (SNES), 1p
+	-Tatakae! Chou Robotto Seimeitai Transformers: Convoy no Nazo (NES), 1p
 	-Tecmo Super Bowl (NES), 1p (on opponent scores, giveaways, giving up first down, failing to get a first down)
 	-Teenage Mutant Ninja Turtles (NES), 1p
 	-Teenage Mutant Ninja Turtles II: The Arcade Game (NES), 1-2p
@@ -7517,6 +7518,22 @@ local gamedata = {
 			local pointer = memory.read_u32_le(0xD8C58, "MainRAM") & 0xFFFFFF
 			return memory.read_u16_le(pointer + 0x170, "MainRAM")
 		end,
+	},
+	['MysteryOfConvoy_NES']={ -- Tatakae! Chou Robotto Seimeitai Transformers: Convoy no Nazo
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return 1 end,
+		p1getlc=function() return memory.read_u8(0x0069, "RAM") end,
+		maxhp=function() return 1 end,
+		other_swaps=function()
+			-- barrier powerup gives some extra health, but damage counter doesn't seem to be exclusively used for tracking barrier damage
+			local hasbarrier_changed, hasbarrier_cur, hasbarrier_prev = update_prev('hasbarrier', memory.read_s8(0x0053, "RAM")==0x60)
+			local barrierdamage_changed, barrierdamage_cur, barrierdamage_prev = update_prev('barrierdamage', memory.read_s8(0x0054, "RAM"))
+			return barrierdamage_changed and hasbarrier_prev and barrierdamage_cur > barrierdamage_prev end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x0069 end,
+		LivesWhichRAM=function() return "RAM" end,
+		maxlives=function() return 70 end,
+		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['TecmoSuperBowl_NES']={ -- Tecmo Super Bowl NES
 		func=TecmoSuperBowl_NES_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -325,6 +325,7 @@ D8B1088520F7C5F81433292A9258C1184AFA1457 StarFox64_N64                -- Star Fo
 7A466684F5928FE656841DF20BCB458E74108239 SuperDodgeBall               -- Super Dodge Ball NES (US) (No Intro Headerless)
 0D994A58B7ACDFE9357E5405ACEBE232128B80FE JUNKY_BALL_MR_GBA            -- Super Monkey Ball Jr. (USA)
 A0F16ED356CF99DE2E1B72FB289C9C7FCE8F2AB3 ContraIII_SNES               -- Super Probotector - Alien Rebels (Europe)
+795323E8660BC793D3B9D3E96908189142F6C75C MysteryOfConvoy_NES          -- Tatakae! Chou Robotto Seimeitai Transformers: Convoy no Nazo
 A2DD48574B9F7A49977C91D12D5C52C17C2C82AA UNSquadron_SNES              -- U.N. Squadron (US)
 0F500AB60B7DDB382F70A9EA3FB68E7FC593091C UNSquadron_SNES              -- U.N. Squadron (-grind hack)
 B9E2FCAABC7BB71BEC3B6AD4BA1CD26E2A441A9C UNSquadron_SNES              -- U.N. Squadron (Europe)


### PR DESCRIPTION
Adds support for Tatakae! Chou Robotto Seimeitai Transformers: Convoy no Nazo.

The B (barrier) powerup allows the player to take multiple hits. While this changes the game music similar to invincibility powerups in other NES platformers, it only provides a limited number of hits, not timed invincibility. Shuffling has been implemented for damage while the player has the barrier.

RAM address 0x0054 appears to add one whenever the player takes damage while they have the barrier. Since that address also appears to be used for other things, the shuffling condition also checks address 0x0053, which appears to change to a set value while the barrier is active.