### PR TITLE
Add The Cliffhanger: Edward Randy to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -268,7 +268,7 @@ plugin.description =
 	-Teenage Mutant Ninja Turtles II: The Arcade Game (NES), 1-2p
 	-Teenage Mutant Ninja Turtles III: The Manhattan Project (NES), 1-2p
 	-Teenage Mutant Ninja Turtles IV: Turtles in Time (SNES), 1-2p
-	-The Cliffhanger - Edward Randy (World ver 3) (Arcade), 1p
+	-The Cliffhanger - Edward Randy (Arcade), 1p
 	-The Magical Quest Starring Mickey Mouse (SNES), 1-2p
 	-The Magical Quest 2: The Great Circus Mystery Starring Mickey & Minnie (SNES), 1-2p
 	-The Magical Quest 3: Mickey to Donald - Magical Adventure 3 (SNES), 1-2p

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -268,6 +268,7 @@ plugin.description =
 	-Teenage Mutant Ninja Turtles II: The Arcade Game (NES), 1-2p
 	-Teenage Mutant Ninja Turtles III: The Manhattan Project (NES), 1-2p
 	-Teenage Mutant Ninja Turtles IV: Turtles in Time (SNES), 1-2p
+	-The Cliffhanger - Edward Randy (World ver 3) (Arcade), 1p
 	-The Magical Quest Starring Mickey Mouse (SNES), 1-2p
 	-The Magical Quest 2: The Great Circus Mystery Starring Mickey & Minnie (SNES), 1-2p
 	-The Magical Quest 3: Mickey to Donald - Magical Adventure 3 (SNES), 1-2p
@@ -6635,6 +6636,47 @@ local gamedata = {
 			end
 		return false
 		end,
+	},
+	['EdwardRandy_ARC']={ -- The Cliffhanger - Edward Randy (World ver 3)
+		func=function() return function()
+				local gmode = memory.read_u8(0x0000, "m68000 : ram : 0x194000-0x197FFF")==1
+		
+				-- score doubles as health, and is drained for several frames on damage, so we'll only shuffle when health stops falling to avoid constant shuffle
+				if prevdata["isHealthFalling"] == nil then prevdata["isHealthFalling"] = false end -- set a starting value of false, but do not overwrite a true value
+								
+				-- health (score) is stored as hex over three values each representing two digits, so need to be both converted and combined into a single value
+				local healthHexUnits = memory.read_u8(0x1533, "m68000 : ram : 0x194000-0x197FFF")
+				local healthHexHundreds = memory.read_u8(0x1532, "m68000 : ram : 0x194000-0x197FFF")
+				local healthHexTenThousands = memory.read_u8(0x1531, "m68000 : ram : 0x194000-0x197FFF")
+				
+				-- Get upper nybble, bit-shift right 4 bits
+				local tens = (healthHexUnits & 0xF0)>>4
+				local thousands = (healthHexHundreds & 0xF0)>>4
+				local hundredtens = (healthHexTenThousands & 0xF0)>>4
+				
+				-- Just the lower nybble
+				local ones = healthHexUnits & 0x0F
+				local hundreds = healthHexHundreds & 0x0F
+				local tenthousands = healthHexTenThousands & 0x0F
+				
+				-- Merge 'em
+				local _, health_curr, health_prev = update_prev('health',
+					ones + (10 * tens) + (100 * hundreds) + (1000 * thousands) + (10000 * tenthousands) + (100000 * hundredtens))
+								
+				-- when health is not falling, wait until it is. when health is failing, wait until it stops, then swap.
+				if gmode and health_prev ~= nil then
+					if not prevdata["isHealthFalling"] then 
+						prevdata["isHealthFalling"] = health_curr < health_prev
+					elseif health_curr >= health_prev then
+						return true end
+					end
+				return false end
+			end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x000C end, -- credits provided
+		LivesWhichRAM=function() return "m68000 : ram : 0x194000-0x197FFF" end,
+		maxlives=function() return 0x69 end,
+		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['TaleSpin_NES']={ -- TaleSpin, NES
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -323,6 +323,7 @@ D8B1088520F7C5F81433292A9258C1184AFA1457 StarFox64_N64                -- Star Fo
 42F954E9BD3256C011ABA14C7E5B400ABE35FDE3 SuperDodgeBall               -- Super Dodge Ball NES (US)
 75DAD8B461864DDD396C75BDB68378BB2BC47D99 SuperDodgeBall               -- Super Dodge Ball NES (US) (No Intro Headered)
 7A466684F5928FE656841DF20BCB458E74108239 SuperDodgeBall               -- Super Dodge Ball NES (US) (No Intro Headerless)
+3A3D972860176C856053CF3F16575339DAD28DC2 EdwardRandy_ARC              -- The Cliffhanger - Edward Randy (World ver 3)
 0D994A58B7ACDFE9357E5405ACEBE232128B80FE JUNKY_BALL_MR_GBA            -- Super Monkey Ball Jr. (USA)
 A0F16ED356CF99DE2E1B72FB289C9C7FCE8F2AB3 ContraIII_SNES               -- Super Probotector - Alien Rebels (Europe)
 A2DD48574B9F7A49977C91D12D5C52C17C2C82AA UNSquadron_SNES              -- U.N. Squadron (US)


### PR DESCRIPTION
Adds single player support for The Cliffhanger: Edward Randy.

Note that only single player shuffler support has currently been added, although Edward Randy does feature two player co-op support.

In Edward Randy, the player's score also functions as their health. The player's maximum health is vastly higher than the starting value, and it tends to rise when the player is able to avoid damage. Health also reduces over a period time when damage is taken rather than dropping instantaneously, with visible indicators of taken damage often being unclear.

Shuffling has currently been set up to occur when shuffling stops after dropping for a period.

The Cliffhanger: Edward Randy has been tested primarily in the early game.