### PR TITLE
Add pseudo-3D shmups to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -175,6 +175,7 @@ plugin.description =
 	-Goof Troop (SNES), 1-2p
 	-Gremlins 2: The New Batch (NES), 1p
 	-Gunstar Heroes (Genesis/Mega Drive), 1p
+	-Gyruss (NES), 1p
 	-Hammerin' Harry (NES), 1p
 	-Hercules II (Bootleg) (Genesis/Mega Drive), 1p
 	-High Seas Havoc (Genesis/Mega Drive), 1p
@@ -220,6 +221,7 @@ plugin.description =
 	-Ninja Gaiden II - The Dark Sword of Chaos (NES), 1p
 	-Ninja Gaiden III - The Ancient Ship of Doom (NES), 1p
 	-Ninjawarriors (SNES), 1p
+	-Panorama Cotton (English v1.0.1) (Mega Drive/Genesis), 1p
 	-PaRappa the Rapper (PSX), 1p - shuffles on dropping a rank
 	-Pebble Beach Golf Links (Sega Saturn), 1p - Tournament Mode, shuffles after stroke
 	-Pepsiman (PSX), 1p
@@ -5803,6 +5805,20 @@ local gamedata = {
 		get_health=function() return memory.read_u16_be(0xA424, "68K RAM") end, -- note; health will not go above 999
 		grace=60,
 	},
+	['Gyruss_NES']={ -- Gyruss (NES)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return 1 end, 
+		p1getlc=function() return memory.read_u8(0x002E, "RAM") end,
+		maxhp=function() return 1 end,
+		gmode=function() return memory.read_u8(0x0018, "RAM") == 4 end,
+		swap_exceptions=function() return memory.read_u8(0x0051, "RAM") == 0 end, -- prevent shuffle between stages; player gets an extra life and dies to show revive animation
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x002E end,
+		LivesWhichRAM=function() return "RAM" end,
+		maxlives=function() return 7 end,
+		ActiveP1=function() return true end, -- p1 is always active!
+		other_swaps=function() return false end,
+	},
 	['ContraHardCorps_GEN']={ -- Contra - Hard Corps, Genesis
 		func=twoplayers_withlives_swap,
 		p1gethp=function() return memory.read_u8(0xFA0D, "68K RAM") end,
@@ -7764,6 +7780,17 @@ local gamedata = {
 		is_valid_gamestate=function() return true end,
 		get_health=function() return memory.read_u8(0x0018B2, "WRAM") end,
 		other_swaps=function() return false end,
+	},
+	['PanoramaCotton_GEN']={ -- Panorama Cotton (English v1.0.1	)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u16_be(0x00F36C, "68K RAM") end,
+		p1getlc=function() return memory.read_u8(0x00F31F, "68K RAM") end,
+		maxhp=function() return 1200 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x00F31F end,
+		LivesWhichRAM=function() return "68K RAM" end,
+		maxlives=function() return 5 end,
+		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['Gremlins2_NES']={ -- Gremlins 2: The New Batch, NES (US)
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -280,6 +280,7 @@ D3EFD32B68F1FE37A82DB9D9929B7CA7CC1A3AF4 FZERO_SNES                   -- F-Zero 
 A582DF3B880A0C8DDC1CDA358C96E306C1E222BB FZERO_SNES                   -- F-Zero SNES with 3 lap hack
 3F20C2C8749CCEE3A53732B41AE026BF3AAA2158 FamilyFeud_SNES              -- Family Feud SNES (US 1.0)
 8556B6545B78022FE55705A83C3E751C463F56C7 FamilyFeud_SNES              -- Family Feud SNES (US 1.1)
+704721C0B1209CB2BAE8AC1C22F2D3BC3FD53EDB Gyruss_NES                   -- Gyruss (NES)
 09D97003BF9D676F24A75CF3E1DCED28CDA3BE59 IceClimber_NES               -- Ice Climber (North America, Europe)
 1690E419BC2435739EFBE59A64D83538FF7E16B4 IceClimber_NES               -- Ice Climber (Japan)
 86C392A1D9A731FA48E148AFBE60AF75F918CB5A Jackal_NES                   -- Jackal NES
@@ -306,6 +307,7 @@ B1796660E4A4CEFC72181D4BF4F97999BC048A77 NinjaGaiden2_NES             -- Ninja G
 3F2E6DAC76BA14EFC177B5653AB043E53A04D365 NinjaGaiden3_NES             -- Ninja Gaiden III NES (US)
 6958358C4A554BDC6D4F8571F83829989D0BB018 NinjaGaiden3_NES             -- Ninja Gaiden III NES (Restored & Restored+ hack)
 2FF9443C                                 NBA_JAM_PS1                  -- NBA Jam Tournament Edition, PS1 (North America)
+CC4580A855AE032E87C3419DDA773FA600397873 PanoramaCotton_GEN           -- Panorama Cotton (English v1.0.1)
 BA9742A4                                 PaRappa1_PS1                 -- PaRappa the Rapper, PS1 (US)
 24AD606614D7D2A510F5FD58FCDC28FE         PEBBLE_BEACH_GOLF_LINKS_SAT  -- Pebble Beach Golf Links, Saturn (North America)
 6531FF3A062C2A83FA9683BF8A859A3500E8D9AF Contra_NES                   -- Probotector (NES) (Europe)


### PR DESCRIPTION
Adds support for Panorama Cotton for the Mega Drive/Genesis and Gyruss for the NES.

Gyruss starts off a stage with the flashy revival animation; to do that, it actually gives the player an extra life and kills them when the stage starts. swap_exceptions has been defined to supress this false shuffle by checking RAM address 0x0051 which seems to display a consistent value while the player has been given this fake extra life.

Both games have been tested primarily in the early game. Panorama Cotton has been tested using the Malias English translation.