### PR TITLE
Add Bonanza Bros to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -141,7 +141,7 @@ plugin.description =
 	-Bao Qing Tian (Ch) (NES), 1p
 	-Batman (NES), 1p
 	-Blades of Steel (NES - NA/Europe), 1-2p
-	-Bonanza Bros (US, Floppy DS3-5000-07d? Based) (Arcade), 1p
+	-Bonanza Bros (Arcade), 1p
 	-Bonk's Adventure (TG-16), 1p
 	-Bubble Bobble (NES), 1p
 	-Bubsy in Claws Encounters of the Furred Kind (aka Bubsy 1) (SNES), 1p

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -141,6 +141,7 @@ plugin.description =
 	-Bao Qing Tian (Ch) (NES), 1p
 	-Batman (NES), 1p
 	-Blades of Steel (NES - NA/Europe), 1-2p
+	-Bonanza Bros (US, Floppy DS3-5000-07d? Based) (Arcade), 1p
 	-Bonk's Adventure (TG-16), 1p
 	-Bubble Bobble (NES), 1p
 	-Bubsy in Claws Encounters of the Furred Kind (aka Bubsy 1) (SNES), 1p
@@ -4806,6 +4807,18 @@ local gamedata = {
 			-- if both fighters just dropped to 0, that's "end of battle"
 			-- update_prev set up because there could be further exceptions identified later
 		CanHaveInfiniteLives=false, -- Blades of Steel does not work this way.
+	},
+	['BonanzaBros_ARC']={ -- Bonanza Bros (US, Floppy DS3-5000-07d? Based)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return memory.read_u8(0x00059A, "m68000 : ram : 0xF00000-0xF3FFFF") end, -- lives
+		p1getlc=function() return memory.read_u8(0x038428, "m68000 : ram : 0x80000-0xBFFFF") end, -- coins: seems to revert if pushed too high at once
+		maxhp=function() return 9 end,
+		gmode=function() return memory.read_u8(0x000405, "m68000 : ram : 0xF00000-0xF3FFFF")==4 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x00059A end,
+		LivesWhichRAM=function() return "m68000 : ram : 0xF00000-0xF3FFFF" end,
+		maxlives=function() return 9 end,
+		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['DoubleDragon1_NES']={ -- Double Dragon NES
 		func=twoplayers_withlives_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -232,6 +232,7 @@ E68578447EAA2F711C83244BE4653CC241D38A50 BATMAN_NES                   -- Batman,
 1AA1E36483D766ECE1E8A72409BF12397FF262D6 BladesofSteel_NES            -- Blades of Steel, NES (US)
 0EDB36400187C445E0389253ABBC31A5603523C4 BladesofSteel_NES            -- Blades of Steel, NES (Europe)
 967E054C94205BDCF97E377D14C41DF55EADB9CA BladesofSteel_NES            -- Blades of Steel, NES (US, 10-minute periods hack)
+DF5CD360E3E93730DF44B564D72E9CE5CE5BBF02 BonanzaBros_ARC              -- Bonanza Bros (US, Floppy DS3-5000-07d? Based)
 9F6FF6264E0361E074F9CFEE2EC4976866A781C5 BUBSY1_SNES                  -- Bubsy in Claws Encounters of the Furred Kind SNES (US)
 72CFB569819DA4E799BF8FA1A6F023664CC7069B CaptainNovolin               -- Captain Novolin SNES
 39A5FDB7EFD4425A8769FD3073B00DD85F6CD574 CNDRR1_NES                   -- Chip and Dale Rescue Rangers NES (US)


### PR DESCRIPTION
Adds single player support for Bonanza Bros.

Coins seem to revert if pushed to too high a value at once, which enforces that infinite lives should be provided instead of infinite coins.