### PR TITLE
 Add Legendary Axe to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -4270,24 +4270,9 @@ local gamedata = {
 	},
 	['LegendaryAxe_TG16']={ -- The Legendary Axe (U)
 		func=singleplayer_withlives_swap,
-		p1gethp=function() 
-			-- Legendary Axe uses one value for each full visible unit on the health bar.
-			local health_fullunits, health_subunits
-			
-			health_fullunits = memory.read_u8(0x0093, "Main Memory")
-			if health_fullunits == 0x10 then health_fullunits = 10 end -- the value is stored as hex, but since 10 is the highest value, we only need to convert 10 
-			health_fullunits = health_fullunits * 3 -- Since the subunit has three possible values, we'll treat a full unit as valued 3.
-			
-			--there are three subunits of health, but they aren't stored consistently, so must be translated. The values progress as 11X or 10X > 5X or 6X > X. The units digit is not meaningful.
-			health_subunits = memory.read_u8(0x0092, "Main Memory")
-			if health_subunits > 100 then health_subunits = 2
-				elseif health_subunits > 50 then health_subunits = 1
-				else health_subunits = 0 end
-
-			-- treat the combined values as a single health value
-			return health_fullunits + health_subunits end,
+		p1gethp=function() return memory.read_u16_le(0x0092, "Main Memory") end,
 		p1getlc=function() return memory.read_s8(0x0009, "Main Memory") end,
-		maxhp=function() return 30 end, -- health begins with a full unit value of 10 and the subunits value are 0, which we can treat as (3*10)+0=30
+		maxhp=function() return 0x1000 end,
 		gmode=function() return memory.read_u8(0x0FC5, "Main Memory")==63 end,
 		CanHaveInfiniteLives=true,
 		p1livesaddr=function() return 0x0009 end,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -193,6 +193,7 @@ plugin.description =
 	-Kabuki Quantum Fighter (NES), 1p
 	-Kuru Kuru Kururin (GBA), 1p
 	-Last Alert (TG-16 CD), 1p
+	-The Legendary Axe (U) (TG-16), 1p
 	-Little Samson (NES), 1p
 	-Lion King, The (NES), 1p
 	-Lion King, The (bootleg) (NES), 1p
@@ -4266,6 +4267,33 @@ local gamedata = {
 				return 1
 			end
 		end,
+	},
+	['LegendaryAxe_TG16']={ -- The Legendary Axe (U)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() 
+			-- Legendary Axe uses one value for each full visible unit on the health bar.
+			local health_fullunits, health_subunits
+			
+			health_fullunits = memory.read_u8(0x0093, "Main Memory")
+			if health_fullunits == 0x10 then health_fullunits = 10 end -- the value is stored as hex, but since 10 is the highest value, we only need to convert 10 
+			health_fullunits = health_fullunits * 3 -- Since the subunit has three possible values, we'll treat a full unit as valued 3.
+			
+			--there are three subunits of health, but they aren't stored consistently, so must be translated. The values progress as 11X or 10X > 5X or 6X > X. The units digit is not meaningful.
+			health_subunits = memory.read_u8(0x0092, "Main Memory")
+			if health_subunits > 100 then health_subunits = 2
+				elseif health_subunits > 50 then health_subunits = 1
+				else health_subunits = 0 end
+
+			-- treat the combined values as a single health value
+			return health_fullunits + health_subunits end,
+		p1getlc=function() return memory.read_s8(0x0009, "Main Memory") end,
+		maxhp=function() return 30 end, -- health begins with a full unit value of 10 and the subunits value are 0, which we can treat as (3*10)+0=30
+		gmode=function() return memory.read_u8(0x0FC5, "Main Memory")==63 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x0009 end,
+		LivesWhichRAM=function() return "Main Memory" end,
+		maxlives=function() return 9 end,
+		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['PEBBLE_BEACH_GOLF_LINKS_SAT']={ -- Pebble Beach Golf Links, Sega Saturn
 		func=Pebble_Beach_Golf_Links_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -193,7 +193,7 @@ plugin.description =
 	-Kabuki Quantum Fighter (NES), 1p
 	-Kuru Kuru Kururin (GBA), 1p
 	-Last Alert (TG-16 CD), 1p
-	-The Legendary Axe (U) (TG-16), 1p
+	-The Legendary Axe (TG-16), 1p
 	-Little Samson (NES), 1p
 	-Lion King, The (NES), 1p
 	-Lion King, The (bootleg) (NES), 1p

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -291,6 +291,7 @@ F324E7C8C3AD102ECDCCA011ECC494F6F345D768 KIRBY_NES                    -- Kirby's
 5C2810BCA7659F3AEB4A993B1C38F228B0FC1C0E KIRBY_NES                    -- Kirby's Adventure NES (US 1.1) (No Intro Headered)
 118307DA6C77A592F0884BAAD14120301D8D3A1B KIRBY_NES                    -- Kirby's Adventure NES (US 1.1) (No Intro Headerless)
 33D4467131049E22E34A02DBA43D3F3D         LAST_ALERT_TGCD              -- Last Alert, TurboGrafx-CD (North America)
+F69B506237CE7D05E7F839D2CC96AB5A         LegendaryAxe_TG16            -- The Legendary Axe (U)
 DF7CC70BF08E144FE4A1A29F529309A6CEA75A2E LittleSamson_NES             -- Little Samson, NES (US)
 C0E918076CB02A563E2805884FD8B035AB5E06EB LittleSamson_NES             -- Little Samson, NES (Europe)
 BD79216BD8A4D91792E31EE711BA2E2B8D1A3B8B LittleSamson_NES             -- Little Samson (Seirei Densetsu Lickle), NES (Japan)


### PR DESCRIPTION
Adds support for The Legendary Axe.

Health in Legendary Axe appears to be stored as a two byte hex value with a maximum of of 0x1000. From brief testing, I did not find the necessity to adjust for this beyond simply reading the two byte value.