### PR TITLE
Add Monster Rancher Hop-A-Bout to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -212,6 +212,7 @@ plugin.description =
 	-Minnesota Fats - Pool Legend (Saturn), 1p story mode
 	-Ms. Pac-Man (Tengen) (NES), 1p
 	-Monopoly (NES), 1-8p (on one controller), shuffles on any human player going bankrupt, going or failing to roll out of jail, and losing money (not when buying, trading, or setting up game)
+	-Monster Rancher Hop-A-Bout (USA) (PSX), 1p
 	-Mortal Kombat (Genesis/Mega Drive), 1p (for now)
 	-Mortal Kombat II (SNES), 1p (for now)
 	-Mystic Warriors (Arcade), 1p
@@ -4237,6 +4238,13 @@ local gamedata = {
 		getp8Bankrupt=function() return memory.read_u8(0x0333, "RAM") end,
 		
 		CanHaveInfiniteLives=false
+	},
+	['MonsterRancherHopABout_PS1']={ -- Monster Rancher Hop-A-Bout (USA)
+		func=health_swap,
+		is_valid_gamestate=function() return memory.read_u8(0x1FD6A0, "MainRAM")==160 end,
+		get_health=function() return memory.read_u8(0x141451, "MainRAM") end,
+		other_swaps=function() return false end,
+		suspend_updates=function() return memory.read_u8(0x07D2BE, "MainRAM")==160 end, -- suppresses shuffle from life reset to default at the beginning of the stage
 	},
 	['BUBSY1_SNES']={ -- Bubsy in Claws Encounters of the Furred Kind, SNES
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -212,7 +212,7 @@ plugin.description =
 	-Minnesota Fats - Pool Legend (Saturn), 1p story mode
 	-Ms. Pac-Man (Tengen) (NES), 1p
 	-Monopoly (NES), 1-8p (on one controller), shuffles on any human player going bankrupt, going or failing to roll out of jail, and losing money (not when buying, trading, or setting up game)
-	-Monster Rancher Hop-A-Bout (USA) (PSX), 1p
+	-Monster Rancher Hop-A-Bout (PSX), 1p
 	-Mortal Kombat (Genesis/Mega Drive), 1p (for now)
 	-Mortal Kombat II (SNES), 1p (for now)
 	-Mystic Warriors (Arcade), 1p

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -301,6 +301,7 @@ E6E13FB9BE8DE11016EFBAAC9AD5655B8E43B180 MagicalDoropie_NES           -- Magical
 5DB2C9E02D3551292A0218F73875F9F08318ECB9 Monopoly_NES                 -- Monopoly NES (US)
 8B152D1948CE4113F06757D2F33C2DAB9D5E7CCD Monopoly_NES                 -- Monopoly NES (US) (No Intro Headered)
 67FD2B7B9B72B8635515BB37926D77970720E3D6 Monopoly_NES                 -- Monopoly NES (US) (No Intro Headerless)
+2075B1D8                                 MonsterRancherHopABout_PS1   -- Monster Rancher Hop-A-Bout (USA)
 CA513F841D75EFEB33BB8099FB02BEEB39F6BB9C NinjaGaiden1_NES             -- Ninja Gaiden NES (US)
 B1796660E4A4CEFC72181D4BF4F97999BC048A77 NinjaGaiden2_NES             -- Ninja Gaiden II NES (US)
 3F2E6DAC76BA14EFC177B5653AB043E53A04D365 NinjaGaiden3_NES             -- Ninja Gaiden III NES (US)


### PR DESCRIPTION
Adds support for Monster Rancher Hop-A-Bout.

Maximum health can be increased, but only for the duration of the current stage. suspend_updates has been defined to attempt to suppress shuffling due to max health resetting between stages by identifying a value that is consistent at the time that the life value changes.