### PR TITLE
Add Frogger 2: Swampy's Revenge PS1 to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -167,6 +167,7 @@ plugin.description =
 	-Einhänder (PSX), 1p
 	-F-Zero (SNES), 1p
 	-Family Feud (SNES), 1-2p
+	-Frogger 2 - Swampy's Revenge (USA) (PS1), 1p
 	-Garfield: A Week of Garfield (NES), 1p
 	-Gargoyle's Quest II (NES), 1p
 	-Ghosts'n Goblins (NES), 1p
@@ -4151,6 +4152,17 @@ local gamedata = {
 		getstrike=function() return memory.read_u8(0x020E, "WRAM") end,
 		getwhichplayer=function() return memory.read_u8(0x08DF, "WRAM") end,
 		CanHaveInfiniteLives=false
+	},
+	['Frogger2_PS1']={ -- Frogger 2 - Swampy's Revenge (USA)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return 1 end,
+		p1getlc=function() return memory.read_u8(0x0908EC, "MainRAM") end,
+		maxhp=function() return 1 end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x0908EC end,
+		LivesWhichRAM=function() return "MainRAM" end,
+		maxlives=function() return 69 end,
+		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['Monopoly_NES']={ -- Monopoly (NES)
 		func=Monopoly_NES_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -167,7 +167,7 @@ plugin.description =
 	-Einhänder (PSX), 1p
 	-F-Zero (SNES), 1p
 	-Family Feud (SNES), 1-2p
-	-Frogger 2 - Swampy's Revenge (USA) (PS1), 1p
+	-Frogger 2 - Swampy's Revenge (PS1), 1p
 	-Garfield: A Week of Garfield (NES), 1p
 	-Gargoyle's Quest II (NES), 1p
 	-Ghosts'n Goblins (NES), 1p

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -280,6 +280,7 @@ D3EFD32B68F1FE37A82DB9D9929B7CA7CC1A3AF4 FZERO_SNES                   -- F-Zero 
 A582DF3B880A0C8DDC1CDA358C96E306C1E222BB FZERO_SNES                   -- F-Zero SNES with 3 lap hack
 3F20C2C8749CCEE3A53732B41AE026BF3AAA2158 FamilyFeud_SNES              -- Family Feud SNES (US 1.0)
 8556B6545B78022FE55705A83C3E751C463F56C7 FamilyFeud_SNES              -- Family Feud SNES (US 1.1)
+329F3B32                                 Frogger2_PS1                 -- Frogger 2 - Swampy's Revenge (USA)
 09D97003BF9D676F24A75CF3E1DCED28CDA3BE59 IceClimber_NES               -- Ice Climber (North America, Europe)
 1690E419BC2435739EFBE59A64D83538FF7E16B4 IceClimber_NES               -- Ice Climber (Japan)
 86C392A1D9A731FA48E148AFBE60AF75F918CB5A Jackal_NES                   -- Jackal NES


### PR DESCRIPTION
Adds support for Frogger 2: Swampy's Revenge for the original PlayStation.

Frogger 2 has been tested in the main Swampy's Revenge mode up to post-tutorial level 3: Croc's Away / Grindstone.