### PR TITLE
Add Super Mario World (Hummer Team bootleg) to shuffler 

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -50,6 +50,7 @@ plugin.description =
 	-Super Mario World 2: Yoshi's Island (SNES), 1p plus 2p secret mini battles
 	--- check toggle for whether you want mini battle damage/losses to swap!
 	-Super Mario All-Stars (SNES), 1-2p, with or without World (includes SMB3 battle mode)
+	-Super Mario World (Hummer Team bootleg), 1p
 	-Super Mario Land (GB or GBC DX patch), 1p
 	-Super Mario Land 2: 6 Golden Coins (GB or GBC DX patch), 1p
 	-Super Mario 64 (N64), 1p - including Better Non-Stop hack
@@ -3127,6 +3128,26 @@ local gamedata = {
 				return false
 			end
 		end,
+	},
+	['HummerMarioWorld_NES']={ -- Super Mario World (Asia) (En) (Pirate)
+		func=singleplayer_withlives_swap,
+		p1gethp=function() return 1 end, 
+		p1getlc=function() return memory.read_u8(0x036A, "RAM") end,
+		maxhp=function() return 1 end,
+		minhp=-1,
+		gmode=function() return memory.read_u8(0x0602, "RAM")==247 end,
+		other_swaps=function()
+			-- current power up: 0 = small mario, 1 = super mario, 2 = fire mario, 3 = cape mario
+			local powerup_changed, powerup_curr, powerup_prev = update_prev('powerup', memory.read_u8(0x0624, "RAM"))
+			
+			-- swap only when player is returned to small mario form, not switches between powerups
+			if powerup_changed and powerup_curr==0 then return true end
+			return false end,
+		CanHaveInfiniteLives=true,
+		p1livesaddr=function() return 0x036A end,
+		LivesWhichRAM=function() return "RAM" end,
+		maxlives=function() return 69 end,
+		ActiveP1=function() return true end, -- p1 is always active!
 	},
 	['SML1_GB']={ -- Super Mario Land, including DX hack for Game Boy Color
 		func=sml1_swap,

--- a/plugins/chaos-shuffler-hashes.dat
+++ b/plugins/chaos-shuffler-hashes.dat
@@ -107,6 +107,7 @@ B9ED5789C9F481E25A64DAD1C5E8E93E4DDC1B80 SML2_GB                      -- Super M
 FAC071FF28CD5D27D0DF465EC124B925C9A5D3D9 SMK_SNES                     -- Super Mario Kart with 3 lap hack
 1D85648EF0D2230DE49153FC94297122BABB5926 SOMARI                       -- Somari NES (unlicensed)
 6CF18228CFB66D48B3642069979D4A5103CB8528 SOMARI                       -- Somari NES (unlicensed)
+A9D568E5DB93033AD11128F2DB82DF3F49085EE2 HummerMarioWorld_NES         -- Super Mario World (Asia) (En) (Pirate)
 C807F2856F44FB84326FAC5B462340DCDD0471F8 SMW2YI_SNES                  -- Super Mario World 2 Yoshi's Island SNES (US 1.0)
 34612A93741F156D6E497462AB7F253CB8A959A0 SMW2YI_SNES                  -- Super Mario World 2 Yoshi's Island SNES (US 1.1)
 A2DDBA012E5C3C2096D0BE57CC273BE5         NSMB_DS                      -- New Super Mario Bros DS (US)


### PR DESCRIPTION
Adds support for Super Mario World for NES.

As well as losing a life, shuffling has been implemented on being reduced to small Mario from Super Mario, Fire Mario, or Cape Mario. Shuffling for losing Yoshi due to damage has currently not been implemented.

Note that the game allows you to choose how many worlds have been completed at the start for whatever reason, which should be convenient if additional testing is needed: by picking 7, you immediately unlock all of the stages in the game.

Game has been tested into Donut Plains 3 (the level after the Donut Plains Yoshi's House). 