### PR TITLE
Fix Astro Boy: Omega Factor

### DIFF
--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -8047,7 +8047,12 @@ local gamedata = {
 		func=health_swap,
 		is_valid_gamestate=function() return true end,
 		get_health=function() return memory.read_u32_le(0x2802, "IWRAM") end,
-		other_swaps=function() return false end,
+		other_swaps=function() 
+			-- shuffle on missing the qte in the battle with blue knight
+			local qtestate_changed, qtestate_curr, qtestate_prev = update_prev('qtestate', memory.read_u8(0x5219, "IWRAM"))
+			
+			return memory.read_u8(0x12E3, "IWRAM")==4 and  memory.read_u8(0x12E4, "IWRAM")==5 -- indicate that we're in the blue knight fight (row 4, column 5 on select screen)
+			and qtestate_changed and qtestate_curr==88 end, -- indicate that we've changed to the dying state from failed qte
 	},
 	['JurassicPark1_SNES']={ -- Jurassic Park, SNES (USA)
 		func=singleplayer_withlives_swap,

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -8049,7 +8049,7 @@ local gamedata = {
 			-- max health changes depending on difficulty mode. prevent shuffling when different difficulty modes are selected
 			local max_health_changed, max_health_curr, max_health_prev = update_prev('max_health', memory.read_u8(0x2806, "IWRAM"))
 			return not max_health_changed end,
-		get_health=function() return memory.read_u32_le(0x2802, "IWRAM") end,
+		get_health=function() return memory.read_u8(0x2802, "IWRAM") end,
 		other_swaps=function() 
 			-- shuffle on missing the qte in the battle with blue knight
 			local qtestate_changed, qtestate_curr, qtestate_prev = update_prev('qtestate', memory.read_u8(0x5219, "IWRAM"))

--- a/plugins/chaos-damage-shuffler.lua
+++ b/plugins/chaos-damage-shuffler.lua
@@ -8045,7 +8045,10 @@ local gamedata = {
 	},
 	['AstroBoyOmegaFactor_GBA']={ -- Astro Boy - Omega Factor, GBA (USA)
 		func=health_swap,
-		is_valid_gamestate=function() return true end,
+		is_valid_gamestate=function() 
+			-- max health changes depending on difficulty mode. prevent shuffling when different difficulty modes are selected
+			local max_health_changed, max_health_curr, max_health_prev = update_prev('max_health', memory.read_u8(0x2806, "IWRAM"))
+			return not max_health_changed end,
 		get_health=function() return memory.read_u32_le(0x2802, "IWRAM") end,
 		other_swaps=function() 
 			-- shuffle on missing the qte in the battle with blue knight


### PR DESCRIPTION
Miscellaneous fixes / improvements for Astro Boy: The Omega Factor for Gameboy Advance.

The battle with Blue Knight is a QTE event wherein failing the QTE leads to the game over menu. It currently does not shuffle on failure as it does not touch health at all. To that end, other_swaps has been defined in this fix to shuffle on the failed QTE. The other deviances from standard gameplay, mainly shmup-style, should all be using the health bar and thus should be shuffling normally.

The player's maximum health value varies depending on the difficulty mode setting of the current save, and accordingly the current health is set to that max health value whenever a save file is opened. This leads to a potential accidental shuffle if switching to a different save file, such as from an easy save to a hard save. This fix defines is_valid_gamestate so that shuffling does not occur on the frame when max health is changed, at which point current health will also be set to match.

get_health currently reads the health value as a 4 byte value. While the displayed health value goes up to 100000, the last three digits appear to be almost entirely cosmetic, with 1000 being the minimum amount of damage, excepting that health may briefly drop to 1 before hitting 0. Since the actual health value appears to be a single byte ranging from 0 to 100, reading a single appears to better represent health.